### PR TITLE
Parallel AI provider calls, atomic key rotation, DB indexes, temp file safety

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -11,7 +11,7 @@ import subprocess
 import sqlite3
 import redis
 import uuid
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import urljoin
 from logging.handlers import RotatingFileHandler
 from PIL import Image
@@ -303,7 +303,7 @@ def analyze_image_gemini(config, encoded_image, prompt):
     req_id = config.get('request_id', 'legacy')
     tag = f"[{config['name']}][{req_id}]"
 
-    start_idx = int(r.get(f'gemini_key_idx:{config_id}') or 0)
+    start_idx = r.incr(f'gemini_key_idx:{config_id}') % len(keys)
 
     for attempt in range(len(keys) * len(GEMINI_MODELS)):
         key_i = (start_idx + attempt // len(GEMINI_MODELS)) % len(keys)
@@ -319,7 +319,6 @@ def analyze_image_gemini(config, encoded_image, prompt):
             logging.info(f"{tag} Gemini image: key {key_i + 1}/{len(keys)}, {model}")
             resp = requests.post(url, json=payload, timeout=30)
             if resp.status_code == 200:
-                r.set(f'gemini_key_idx:{config_id}', (key_i + 1) % len(keys))
                 return resp.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
             elif resp.status_code == 429:
                 logging.warning(f"{tag} Rate limited: key {key_i + 1}, {model}")
@@ -346,7 +345,7 @@ def analyze_video_gemini(config, video_path, prompt):
     req_id = config.get('request_id', 'legacy')
     tag = f"[{config['name']}][{req_id}]"
 
-    start_idx = int(r.get(f'gemini_key_idx:{config_id}') or 0)
+    start_idx = r.incr(f'gemini_key_idx:{config_id}') % len(keys)
 
     for ki in range(len(keys)):
         key_i = (start_idx + ki) % len(keys)
@@ -411,7 +410,6 @@ def analyze_video_gemini(config, video_path, prompt):
                 try:
                     resp = requests.post(url, json=payload, timeout=60)
                     if resp.status_code == 200:
-                        r.set(f'gemini_key_idx:{config_id}', (key_i + 1) % len(keys))
                         result = resp.json()["candidates"][0]["content"]["parts"][0]["text"].strip()
                         logging.info(f"{tag} Video analysis succeeded with {model}")
                         return result
@@ -736,17 +734,38 @@ def request_bi_export(config, output_path, tag, timeout=300):
 # Image / Still fallback analysis
 # =============================================================================
 
+def analyze_image_parallel(config, encoded_image, prompt):
+    """Run all configured AI providers concurrently; return the first successful result."""
+    providers = []
+    if config.get('gemini_key', '').strip():
+        providers.append(lambda: analyze_image_gemini(config, encoded_image, prompt))
+    if config.get('grok_api_key', '').strip():
+        providers.append(lambda: analyze_image_grok(config, encoded_image, prompt))
+    if config.get('groq_api_key', '').strip():
+        providers.append(lambda: analyze_image_groq(config, encoded_image, prompt))
+    if not providers:
+        return None
+    ex = ThreadPoolExecutor(max_workers=len(providers))
+    try:
+        futures = {ex.submit(fn): fn for fn in providers}
+        for future in as_completed(futures):
+            try:
+                result = future.result()
+                if result:
+                    return result
+            except Exception as e:
+                logging.warning(f"[parallel AI] provider error: {e}")
+    finally:
+        ex.shutdown(wait=False)  # Don't block on remaining providers once we have a result
+    return None
+
+
 def analyze_still_image_fallback(image_path, prompt, config):
-    """PLAN C: Fallback to Still image AI models if Gemini Video fails."""
+    """PLAN C: Fallback to still image analysis if Gemini Video fails."""
     encoded = optimize_image(image_path)
     if not encoded:
         return None
-    ai_text = analyze_image_gemini(config, encoded, prompt)
-    if not ai_text:
-        ai_text = analyze_image_grok(config, encoded, prompt)
-    if not ai_text:
-        ai_text = analyze_image_groq(config, encoded, prompt)
-    return ai_text
+    return analyze_image_parallel(config, encoded, prompt)
 
 
 # =============================================================================
@@ -773,13 +792,7 @@ def process_alert(image_path, config):
         encoded = optimize_image(image_path)
         instant_notify = config.get('instant_notify') == 1
 
-        ai_text = None
-        if encoded:
-            ai_text = analyze_image_gemini(config, encoded, prompt)
-            if not ai_text:
-                ai_text = analyze_image_grok(config, encoded, prompt)
-            if not ai_text:
-                ai_text = analyze_image_groq(config, encoded, prompt)
+        ai_text = analyze_image_parallel(config, encoded, prompt) if encoded else None
 
         still_caption = ai_text or "Motion detected."
 
@@ -803,6 +816,8 @@ def process_alert(image_path, config):
         still_caption = enriched_still
 
         # Video handling
+        raw_mp4 = None
+        optimised_mp4 = None
         if config.get('send_video') == 1 and config.get('trigger_filename'):
             if config.get('bi_url') and config.get('bi_user') and config.get('bi_pass'):
                 raw_mp4 = image_path.replace(".jpg", "_raw.mp4")
@@ -849,5 +864,6 @@ def process_alert(image_path, config):
     except Exception as e:
         logging.error(f"{tag} Task failed: {e}")
     finally:
-        if os.path.exists(image_path):
-            os.remove(image_path)
+        for p in [image_path, raw_mp4, optimised_mp4]:
+            if p and os.path.exists(p):
+                os.remove(p)

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -125,6 +125,8 @@ def init_db():
                 dvla_api_key TEXT
             )
         """)
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_configs_chat_id ON configs(chat_id)")
+        conn.execute("CREATE INDEX IF NOT EXISTS idx_configs_created_at ON configs(created_at)")
         # Migrations for existing installs
         for col, definition in [
             ("last_triggered", "TIMESTAMP"),


### PR DESCRIPTION
## Summary

- **Parallel AI analysis**: `analyze_image_parallel()` submits Gemini, Grok, and Groq concurrently and returns the first successful result. Cuts worst-case image analysis latency from ~90s (sequential timeouts) to ~30s when a provider rate-limits or fails.
- **Atomic Gemini key rotation**: Replace the non-atomic `r.get()` + `r.set()` read-modify-write with `r.incr()`, eliminating the race condition across 4 concurrent workers that caused keys to cluster on the same index.
- **DB indexes**: Add indexes on `configs.chat_id` and `configs.created_at` to avoid full table scans on every page load and mute status check.
- **Temp file safety**: Define `raw_mp4`/`optimised_mp4` at function scope so the `finally` block cleans them up even if the job crashes mid-pipeline.

## Test plan

- [ ] Trigger an alert with a rate-limited Gemini key — confirm Grok/Groq result arrives in ~30s instead of 60s+
- [ ] Watch logs across concurrent alerts — confirm Gemini key numbers (`key 1/4`, `key 2/4`, etc.) are distributed across workers rather than all hitting key 1
- [ ] Verify SQLite schema: `sqlite3 data/configs.db '.indexes'` shows the two new indexes
- [ ] Kill a worker mid-job, confirm no orphaned `_raw.mp4` or `.mp4` files in `/tmp_images`

🤖 Generated with [Claude Code](https://claude.com/claude-code)