### PR TITLE
Issue #76 - Add structured BI pipeline lifecycle logging

### DIFF
--- a/app/bi_downloader.py
+++ b/app/bi_downloader.py
@@ -10,6 +10,7 @@ import time
 from logging.handlers import RotatingFileHandler
 
 from bi_export_shared import (
+    VIDEO_DELIVERY_QUEUE,
     DOWNLOAD_REQUEST_QUEUE,
     DOWNLOAD_TIMEOUT,
     MAX_RECOVERY_ATTEMPTS,
@@ -17,6 +18,7 @@ from bi_export_shared import (
     finish_job,
     get_session,
     job_tag,
+    log_job_event,
     load_job,
     mark_delivery_queued,
     r,
@@ -75,12 +77,24 @@ def _download_export(job):
 
                 final_size = os.path.getsize(job["output_path"])
                 if final_size > 1024:
-                    logging.info(f"{tag} Download complete elapsed={attempt_elapsed:.1f}s size={final_size}")
+                    log_job_event(
+                        logging.INFO,
+                        f"{tag} download complete",
+                        job,
+                        elapsed=f"{attempt_elapsed:.1f}s",
+                        size=final_size,
+                    )
                     downloaded = True
                     break
                 time.sleep(2)
         except Exception as exc:
-            logging.warning(f"{tag} Download error: {safe_error_summary(exc)}")
+            log_job_event(
+                logging.WARNING,
+                f"{tag} download attempt failed",
+                job,
+                elapsed=f"{attempt_elapsed:.1f}s",
+                error=safe_error_summary(exc),
+            )
             time.sleep(2)
 
     if not downloaded:
@@ -101,21 +115,32 @@ def _process_download_request(request_id):
     job["download_attempts"] = int(job.get("download_attempts", 0)) + 1
     job["last_transition_at"] = time.time()
     save_job(job)
+    tag = job_tag(job)
 
     ok, error_msg = _download_export(job)
     if ok:
         finish_job(job, True, None)
         if job.get("delivery_context"):
             mark_delivery_queued(load_job(job["request_id"]) or job)
+            log_job_event(
+                logging.INFO,
+                f"{tag} delivery queued after download",
+                load_job(job["request_id"]) or job,
+                delivery_queue_depth=r.llen(VIDEO_DELIVERY_QUEUE),
+            )
         return
 
-    tag = job_tag(job)
     if job.get("recovery_attempts", 0) < MAX_RECOVERY_ATTEMPTS and trigger_bi_recovery(
         job.get("restart_url", ""),
         job.get("restart_token", ""),
         tag,
     ):
-        logging.warning(f"{tag} Download failed; retrying export after BI recovery")
+        log_job_event(
+            logging.WARNING,
+            f"{tag} download failed; retrying export after recovery",
+            job,
+            error=error_msg,
+        )
         job["request"]["_recovery_attempts"] = job.get("recovery_attempts", 0) + 1
         queue_retry(job, error_msg or "download failed")
         return

--- a/app/bi_export_shared.py
+++ b/app/bi_export_shared.py
@@ -73,6 +73,42 @@ def job_tag(job):
     return f"[{job.get('config_name', '?')}][{correlation_id[:8]}]"
 
 
+def _job_log_fields(job=None, **extra):
+    fields = {}
+    if job:
+        fields.update({
+            "camera": job.get("config_name", "?"),
+            "alert_id": (job.get("alert_request_id") or job.get("request_id") or "unknown")[:8],
+            "job_id": (job.get("request_id") or "unknown")[:8],
+            "state": job.get("status", ""),
+            "delivery_state": job.get("delivery_status", ""),
+            "export_attempt": job.get("export_attempts", 0),
+            "recovery_attempt": job.get("recovery_attempts", 0),
+            "download_attempt": job.get("download_attempts", 0),
+            "delivery_attempt": job.get("delivery_attempts", 0),
+        })
+    fields.update({k: v for k, v in extra.items() if v is not None and v != ""})
+    return fields
+
+
+def format_log_fields(job=None, **extra):
+    fields = _job_log_fields(job, **extra)
+    ordered = []
+    for key in sorted(fields):
+        value = fields[key]
+        ordered.append(f"{key}={value}")
+    return " ".join(ordered)
+
+
+def log_job_event(level, message, job=None, **extra):
+    logger = logging.getLogger()
+    line = message
+    suffix = format_log_fields(job, **extra)
+    if suffix:
+        line = f"{line} | {suffix}"
+    logger.log(level, line)
+
+
 def session_key(bi_url, bi_user):
     digest = hashlib.sha256(f"{bi_url}|{bi_user}".encode("utf-8")).hexdigest()
     return f"{SESSION_KEY_PREFIX}{digest}"

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -19,6 +19,8 @@ from bi_export_shared import (
     bi_get_export_queue,
     bi_resolve_export_target,
     get_session,
+    job_tag,
+    log_job_event,
     r,
     safe_error_summary,
     save_job,
@@ -135,7 +137,7 @@ def _process_request(raw):
         return
 
     request_id = req.get("request_id", "unknown")
-    tag = f"[{req.get('config_name', '?')}][{request_id[:8]}]"
+    tag = job_tag(req)
     queued_at = req.get("queued_at", 0)
     if queued_at and (time.time() - queued_at) > STALE_REQUEST_AGE:
         write_result(request_id, req.get("output_path"), False, "stale request")
@@ -152,7 +154,14 @@ def _process_request(raw):
 
     save_job(job)
     r.sadd(ACTIVE_EXPORT_SET, request_id)
-    logging.info(f"{tag} Export queued as {job['target_path']}; awaiting queue monitor acknowledgement")
+    log_job_event(
+        logging.INFO,
+        f"{tag} export submitted",
+        job,
+        target_path=job["target_path"],
+        relative_uri=job["relative_uri"],
+        queue="bi:export:requests",
+    )
 
 
 def run_exporter():

--- a/app/bi_queue_monitor.py
+++ b/app/bi_queue_monitor.py
@@ -20,6 +20,7 @@ from bi_export_shared import (
     bi_get_export_queue,
     get_session,
     job_tag,
+    log_job_event,
     load_job,
     queue_poll_interval,
     r,
@@ -93,7 +94,9 @@ def _poll_active_exports():
         try:
             active_exports = bi_get_export_queue(sess, bi_url, sid)
         except Exception as exc:
-            logging.warning(f"{tag} Error polling export queue: {safe_error_summary(exc)}")
+            logging.warning(
+                f"{tag} export queue poll failed | bi_url={bi_url} error={safe_error_summary(exc)}"
+            )
             continue
 
         active_paths = {item.get("path") for item in active_exports if item.get("path")}
@@ -107,10 +110,23 @@ def _poll_active_exports():
                     job["status"] = "queued"
                     job["queue_ack_at"] = now
                     job["last_transition_at"] = now
-                    logging.info(f"{tag} Export {job['target_path']} acknowledged in BI queue")
+                    log_job_event(
+                        logging.INFO,
+                        f"{tag} export acknowledged",
+                        job,
+                        queue_size=queue_size,
+                        target_path=job["target_path"],
+                    )
 
                 if (elapsed - job.get("last_progress_log", 0)) >= QUEUE_PROGRESS_LOG_INTERVAL:
-                    logging.info(f"{tag} Export still in progress after {elapsed:.1f}s (queue size: {queue_size})")
+                    log_job_event(
+                        logging.INFO,
+                        f"{tag} export in progress",
+                        job,
+                        elapsed=f"{elapsed:.1f}s",
+                        queue_size=queue_size,
+                        active_exports=len(request_ids),
+                    )
                     job["last_progress_log"] = elapsed
 
                 job["next_poll_at"] = now + queue_poll_interval(elapsed)
@@ -124,12 +140,25 @@ def _poll_active_exports():
                 save_job(job)
                 r.srem(ACTIVE_EXPORT_SET, job["request_id"])
                 r.rpush(DOWNLOAD_REQUEST_QUEUE, job["request_id"])
-                logging.info(f"{tag} Export {job['target_path']} left queue after {elapsed:.1f}s; queued for download")
+                log_job_event(
+                    logging.INFO,
+                    f"{tag} export ready for download",
+                    job,
+                    elapsed=f"{elapsed:.1f}s",
+                    queue_size=queue_size,
+                    download_queue_depth=r.llen(DOWNLOAD_REQUEST_QUEUE),
+                )
                 continue
 
             if job["status"] == "submitted" and elapsed >= EXPORT_QUEUE_ACK_TIMEOUT:
                 if job.get("export_attempts", 1) < MAX_EXPORT_ATTEMPTS:
-                    logging.warning(f"{tag} Export not acknowledged in queue; retrying submission")
+                    log_job_event(
+                        logging.WARNING,
+                        f"{tag} export acknowledgement timeout; retrying",
+                        job,
+                        elapsed=f"{elapsed:.1f}s",
+                        queue_size=queue_size,
+                    )
                     queue_retry(job, "export not acknowledged by queue monitor")
                 else:
                     job["status"] = "failed"
@@ -150,7 +179,13 @@ def _poll_active_exports():
                     job.get("restart_token", ""),
                     tag,
                 ):
-                    logging.warning(f"{tag} Export queue timeout; retrying after BI recovery")
+                    log_job_event(
+                        logging.WARNING,
+                        f"{tag} export queue timeout; retrying after recovery",
+                        job,
+                        elapsed=f"{elapsed:.1f}s",
+                        queue_size=queue_size,
+                    )
                     job["request"]["_recovery_attempts"] = job.get("recovery_attempts", 0) + 1
                     queue_retry(job, "timed out waiting for BI queue")
                 else:
@@ -159,7 +194,13 @@ def _poll_active_exports():
                     save_job(job)
                     r.srem(ACTIVE_EXPORT_SET, job["request_id"])
                     write_result(job["request_id"], job["output_path"], False, "timed out waiting for BI queue")
-                    logging.error(f"{tag} Export timed out waiting for BI queue")
+                    log_job_event(
+                        logging.ERROR,
+                        f"{tag} export failed waiting for queue",
+                        job,
+                        elapsed=f"{elapsed:.1f}s",
+                        queue_size=queue_size,
+                    )
 
 
 def run_monitor():

--- a/app/bi_watchdog.py
+++ b/app/bi_watchdog.py
@@ -20,6 +20,7 @@ from bi_export_shared import (
     MAX_DELIVERY_ATTEMPTS,
     MAX_EXPORT_ATTEMPTS,
     RETRY_QUEUE_STALE_AGE,
+    VIDEO_DELIVERY_QUEUE,
     WATCHDOG_INTERVAL,
     WATCHDOG_STALE_BUFFER,
     finish_delivery,

--- a/app/bi_watchdog.py
+++ b/app/bi_watchdog.py
@@ -25,6 +25,7 @@ from bi_export_shared import (
     finish_delivery,
     iter_job_ids,
     job_tag,
+    log_job_event,
     load_job,
     mark_delivery_queued,
     queue_retry,
@@ -59,7 +60,7 @@ def _repair_job(job):
     transition_age = now - float(job.get("last_transition_at", job.get("updated_at", now)))
 
     if status in {"submitted", "queued"} and not r.sismember(ACTIVE_EXPORT_SET, request_id):
-        logging.warning(f"{tag} Watchdog re-attaching active export tracking for {status} job")
+        log_job_event(logging.WARNING, f"{tag} watchdog reattaching active export", job)
         r.sadd(ACTIVE_EXPORT_SET, request_id)
         job["next_poll_at"] = 0
         job["last_transition_at"] = now
@@ -68,7 +69,12 @@ def _repair_job(job):
 
     if status == "submitted" and submitted_age >= (EXPORT_QUEUE_ACK_TIMEOUT + WATCHDOG_STALE_BUFFER):
         if job.get("export_attempts", 1) < MAX_EXPORT_ATTEMPTS:
-            logging.warning(f"{tag} Watchdog retrying unacknowledged export")
+            log_job_event(
+                logging.WARNING,
+                f"{tag} watchdog retrying unacknowledged export",
+                job,
+                age=f"{submitted_age:.1f}s",
+            )
             queue_retry(job, "watchdog: export acknowledgement stale")
         else:
             job["status"] = "failed"
@@ -81,7 +87,12 @@ def _repair_job(job):
 
     if status == "queued" and submitted_age >= (EXPORT_QUEUE_TIMEOUT + WATCHDOG_STALE_BUFFER):
         if job.get("export_attempts", 1) < MAX_EXPORT_ATTEMPTS:
-            logging.warning(f"{tag} Watchdog retrying stale queued export")
+            log_job_event(
+                logging.WARNING,
+                f"{tag} watchdog retrying stale queued export",
+                job,
+                age=f"{submitted_age:.1f}s",
+            )
             queue_retry(job, "watchdog: export queue stale")
         else:
             job["status"] = "failed"
@@ -93,14 +104,25 @@ def _repair_job(job):
         return
 
     if status == "ready" and transition_age >= (DOWNLOAD_TIMEOUT + WATCHDOG_STALE_BUFFER):
-        logging.warning(f"{tag} Watchdog requeueing stale ready job for download")
+        log_job_event(
+            logging.WARNING,
+            f"{tag} watchdog requeueing stale ready download",
+            job,
+            age=f"{transition_age:.1f}s",
+            download_queue_depth=r.llen(DOWNLOAD_REQUEST_QUEUE),
+        )
         job["last_transition_at"] = now
         save_job(job)
         r.rpush(DOWNLOAD_REQUEST_QUEUE, request_id)
         return
 
     if status == "retry_queued" and transition_age >= RETRY_QUEUE_STALE_AGE:
-        logging.warning(f"{tag} Watchdog requeueing stalled retry job")
+        log_job_event(
+            logging.WARNING,
+            f"{tag} watchdog requeueing stalled export retry",
+            job,
+            age=f"{transition_age:.1f}s",
+        )
         job["last_transition_at"] = now
         save_job(job)
         r.rpush("bi:export:requests", json.dumps(job["request"]))
@@ -109,13 +131,24 @@ def _repair_job(job):
     if status == "downloaded":
         if job.get("delivery_context") and delivery_status in {None, "queued", "retry_queued", "processing"}:
             if delivery_status in {None, "queued", "retry_queued"} and transition_age >= DELIVERY_QUEUE_STALE_AGE:
-                logging.warning(f"{tag} Watchdog requeueing stale delivery job")
+                log_job_event(
+                    logging.WARNING,
+                    f"{tag} watchdog requeueing stale delivery job",
+                    job,
+                    age=f"{transition_age:.1f}s",
+                    delivery_queue_depth=r.llen(VIDEO_DELIVERY_QUEUE),
+                )
                 mark_delivery_queued(job)
                 return
 
             if delivery_status == "processing" and transition_age >= (DELIVERY_QUEUE_STALE_AGE * 2):
                 if int(job.get("delivery_attempts", 0)) < MAX_DELIVERY_ATTEMPTS:
-                    logging.warning(f"{tag} Watchdog requeueing stuck delivery processing job")
+                    log_job_event(
+                        logging.WARNING,
+                        f"{tag} watchdog requeueing stuck delivery processing",
+                        job,
+                        age=f"{transition_age:.1f}s",
+                    )
                     mark_delivery_queued(job)
                 else:
                     finish_delivery(job, False, "watchdog: delivery processing stale")

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -14,6 +14,7 @@ from bi_export_shared import (
     VIDEO_DELIVERY_QUEUE,
     finish_delivery,
     job_tag,
+    log_job_event,
     load_job,
     requeue_delivery,
     r,
@@ -73,6 +74,7 @@ def _process_delivery_request(request_id):
     job["delivery_status"] = "processing"
     job["last_transition_at"] = time.time()
     save_job(job)
+    log_job_event(logging.INFO, f"{tag} delivery processing started", job)
 
     if not os.path.exists(raw_mp4):
         finish_delivery(job, False, "downloaded video missing from disk")
@@ -87,6 +89,7 @@ def _process_delivery_request(request_id):
     )
     if not media_ok:
         if job["delivery_attempts"] < MAX_DELIVERY_ATTEMPTS:
+            log_job_event(logging.WARNING, f"{tag} telegram media replace failed; retrying", job)
             requeue_delivery(job, "telegram media replace failed")
         else:
             finish_delivery(job, False, "telegram media replace failed")
@@ -102,6 +105,7 @@ def _process_delivery_request(request_id):
 
     _cleanup_paths(optimised_mp4, raw_mp4)
     finish_delivery(load_job(request_id) or job, True, None)
+    log_job_event(logging.INFO, f"{tag} delivery completed", load_job(request_id) or job)
 
 
 def run_video_delivery_worker():


### PR DESCRIPTION
 ## Summary
  - Add consistent structured lifecycle logging across the staged BI pipeline
  - Include shared correlation fields so exporter, queue monitor, downloader, watchdog, and delivery worker logs can be traced end-to-end
  - Prefer the original webhook correlation ID in BI pipeline logs so they line up with the request the operator saw in the webhook and Telegram flow
  - Add queue-depth and attempt-count visibility to make retry, timeout, and stall scenarios easier to diagnose from pasted logs

  ## Problem
  The staged BI pipeline was functionally stronger after the export refactor, but observability was still mostly free-text logging. That made it difficult to debug:
  - which BI job corresponded to which webhook event
  - whether a job stalled in exporter, queue monitor, downloader, watchdog, or delivery
  - how many retries or recovery attempts had already happened
  - whether queue depth or backlog contributed to the failure

  ## What Changed
  A shared structured logging helper was added in `app/bi_export_shared.py`, and BI lifecycle events were updated across:
  - `app/bi_exporter.py`
  - `app/bi_queue_monitor.py`
  - `app/bi_downloader.py`
  - `app/bi_watchdog.py`
  - `app/video_delivery_worker.py`

  Logs now include consistent fields such as:
  - `camera`
  - `alert_id`
  - `job_id`
  - `state`
  - `delivery_state`
  - `export_attempt`
  - `recovery_attempt`
  - `download_attempt`
  - `delivery_attempt`
  - `elapsed`
  - queue depth where relevant

  The BI pipeline also now prefers the original webhook request ID (`alert_id`) instead of only the internal export job UUID when rendering tags, so operators can follow one alert across
  all BI stages.

  ## Expected Behavior
  - Exporter, queue monitor, downloader, watchdog, and delivery logs can be correlated from a single pasted log snippet
  - Retry, timeout, recovery, and queue backlog behavior is much easier to interpret
  - Operators can see where a job is stuck without needing to inspect Redis or code paths manually
  - Log analysis for missing videos or delayed Telegram updates should now be materially easier

Resolves #76 