### PR TITLE
Replace /dev/shm bind mount with named Docker volume for tmp_images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+volumes:
+  tmp_images:
+
 services:
   redis:
     image: redis:alpine
@@ -9,7 +12,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     ports:
       - "5000:5000"
     depends_on:
@@ -25,7 +28,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     depends_on:
       - redis
     environment:
@@ -52,7 +55,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     depends_on:
       - redis
     environment:
@@ -66,7 +69,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     depends_on:
       - redis
     environment:
@@ -80,7 +83,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     depends_on:
       - redis
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     depends_on:
       - redis
     environment:
@@ -110,7 +110,7 @@ services:
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs
-      - /dev/shm:/tmp_images
+      - tmp_images:/tmp_images
     depends_on:
       - redis
     environment:


### PR DESCRIPTION
Closes #82

## Summary
- Replaces `- /dev/shm:/tmp_images` bind mount with a named Docker volume (`tmp_images`) across all services that process video files
- Named volume is stored on disk (`/var/lib/docker/volumes/`) rather than in RAM, so orphaned files from killed workers no longer cause memory pressure
- Cross-container file sharing between `bi_downloader` and `worker` is preserved — both mount the same named volume

## Test plan
- [ ] `docker compose up -d` creates the `tmp_images` volume and recreates affected containers without error
- [ ] Camera alert triggers a video clip download and delivery end-to-end
- [ ] `/dev/shm` usage on the host does not grow during normal alert processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)