### PR TITLE
Improve structured logging, alert summaries, and log source filtering

### DIFF
--- a/app/bi_downloader.py
+++ b/app/bi_downloader.py
@@ -40,11 +40,13 @@ def _download_export(job):
     tag = job_tag(job)
     sess, sid = get_session(job["bi_url"], job["bi_user"], job["bi_pass"], tag)
     if not sid:
-        return False, "BI login failed"
+        return False, "BI login failed", None, None
 
     mp4_url = f"{job['bi_url'].rstrip('/')}/clips/{job['relative_uri']}?dl=1&session={sid}"
     downloaded = False
     dl_start = time.time()
+    final_size = None
+    success_elapsed = None
 
     while time.time() - dl_start < DOWNLOAD_TIMEOUT:
         attempt_elapsed = time.time() - dl_start
@@ -52,7 +54,15 @@ def _download_export(job):
             with sess.get(mp4_url, stream=True, timeout=60) as dl:
                 if dl.status_code == 404:
                     if attempt_elapsed >= 50:
-                        logging.error(f"{tag} Persistent 404 after {attempt_elapsed:.1f}s")
+                        log_job_event(
+                            logging.ERROR,
+                            f"{tag} persistent 404 while waiting for download",
+                            job,
+                            logger=logger,
+                            phase="download_wait",
+                            error_code="persistent_404",
+                            elapsed=f"{attempt_elapsed:.1f}s",
+                        )
                         break
                     time.sleep(2)
                     continue
@@ -69,15 +79,8 @@ def _download_export(job):
 
                 final_size = os.path.getsize(job["output_path"])
                 if final_size > 1024:
-                    log_job_event(
-                        logging.INFO,
-                        f"{tag} download complete",
-                        job,
-                        logger=logger,
-                        elapsed=f"{attempt_elapsed:.1f}s",
-                        size=final_size,
-                    )
                     downloaded = True
+                    success_elapsed = attempt_elapsed
                     break
                 time.sleep(2)
         except Exception as exc:
@@ -86,19 +89,21 @@ def _download_export(job):
                 f"{tag} download attempt failed",
                 job,
                 logger=logger,
+                phase="download_wait",
                 elapsed=f"{attempt_elapsed:.1f}s",
+                error_code="download_attempt_failed",
                 error=safe_error_summary(exc),
             )
             time.sleep(2)
 
     if not downloaded:
         bi_delete_clip(sess, job["bi_url"], sid, job["target_path"], tag)
-        return False, "download failed (file not ready)"
+        return False, "download failed (file not ready)", None, None
 
     if job.get("delete_after", True):
         bi_delete_clip(sess, job["bi_url"], sid, job["target_path"], tag)
 
-    return True, None
+    return True, None, success_elapsed, final_size
 
 
 def _process_download_request(request_id):
@@ -111,17 +116,29 @@ def _process_download_request(request_id):
     save_job(job)
     tag = job_tag(job)
 
-    ok, error_msg = _download_export(job)
+    ok, error_msg, wait_elapsed, final_size = _download_export(job)
     if ok:
         finish_job(job, True, None)
+        completed_job = load_job(job["request_id"]) or job
+        log_job_event(
+            logging.INFO,
+            f"{tag} download complete",
+            completed_job,
+            logger=logger,
+            phase="downloaded",
+            wait_elapsed=f"{wait_elapsed:.1f}s" if wait_elapsed is not None else None,
+            size=final_size,
+        )
         if job.get("delivery_context"):
-            mark_delivery_queued(load_job(job["request_id"]) or job)
+            queue_depth_before = r.llen(VIDEO_DELIVERY_QUEUE)
+            mark_delivery_queued(completed_job)
             log_job_event(
                 logging.INFO,
                 f"{tag} delivery queued after download",
                 load_job(job["request_id"]) or job,
                 logger=logger,
-                delivery_queue_depth=r.llen(VIDEO_DELIVERY_QUEUE),
+                phase="delivery_queued",
+                delivery_queue_depth=queue_depth_before + 1,
             )
         return
 
@@ -135,12 +152,23 @@ def _process_download_request(request_id):
             f"{tag} download failed; retrying export after recovery",
             job,
             logger=logger,
+            phase="download_retry",
             error=error_msg,
+            error_code="download_not_ready",
         )
         job["request"]["_recovery_attempts"] = job.get("recovery_attempts", 0) + 1
         queue_retry(job, error_msg or "download failed")
         return
 
+    log_job_event(
+        logging.ERROR,
+        f"{tag} download failed",
+        job,
+        logger=logger,
+        phase="download_failed",
+        error=error_msg,
+        error_code="download_not_ready",
+    )
     finish_job(job, False, error_msg)
 
 

--- a/app/bi_export_shared.py
+++ b/app/bi_export_shared.py
@@ -9,7 +9,7 @@ import logging
 import os
 import socket
 import time
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from logging.handlers import RotatingFileHandler
 
 import redis
@@ -96,6 +96,11 @@ def job_tag(job):
     return f"[{job.get('config_name', '?')}][{correlation_id[:8]}]"
 
 
+def bi_instance_label(bi_url):
+    parsed = urlparse((bi_url or "").strip())
+    return parsed.netloc or parsed.path or "unknown"
+
+
 def _job_log_fields(job=None, **extra):
     fields = {}
     fields.update({
@@ -114,6 +119,8 @@ def _job_log_fields(job=None, **extra):
             "download_attempt": job.get("download_attempts", 0),
             "delivery_attempt": job.get("delivery_attempts", 0),
         })
+        if job.get("bi_url"):
+            fields["bi_instance"] = bi_instance_label(job["bi_url"])
     fields.update({k: v for k, v in extra.items() if v is not None and v != ""})
     return fields
 

--- a/app/bi_export_shared.py
+++ b/app/bi_export_shared.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import socket
+import sqlite3
 import time
 from urllib.parse import urljoin, urlparse
 from logging.handlers import RotatingFileHandler
@@ -17,6 +18,8 @@ import requests
 
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+DATA_DIR = os.getenv("DATA_DIR", "/app/data")
+DB_FILE = os.path.join(DATA_DIR, "configs.db")
 
 EXPORT_REQUEST_QUEUE     = "bi:export:requests"
 DOWNLOAD_REQUEST_QUEUE   = "bi:download:requests"
@@ -43,6 +46,7 @@ DELIVERY_QUEUE_STALE_AGE = 45
 
 r = redis.from_url(REDIS_URL)
 _session_cache = {}
+_bi_instance_logging_cache = {"checked_at": 0.0, "enabled": True}
 INSTANCE_ID = os.getenv("HOSTNAME") or socket.gethostname()
 
 
@@ -101,6 +105,32 @@ def bi_instance_label(bi_url):
     return parsed.netloc or parsed.path or "unknown"
 
 
+def should_log_bi_instance():
+    now = time.time()
+    cached = _bi_instance_logging_cache
+    if (now - cached["checked_at"]) < 60:
+        return cached["enabled"]
+
+    enabled = True
+    try:
+        with sqlite3.connect(DB_FILE) as conn:
+            count = conn.execute(
+                """
+                SELECT COUNT(DISTINCT TRIM(bi_url))
+                FROM configs
+                WHERE bi_url IS NOT NULL AND TRIM(bi_url) <> ''
+                """
+            ).fetchone()[0]
+            enabled = count > 1
+    except Exception:
+        # Fall back to logging the BI instance when config inspection is unavailable.
+        enabled = True
+
+    cached["checked_at"] = now
+    cached["enabled"] = enabled
+    return enabled
+
+
 def _job_log_fields(job=None, **extra):
     fields = {}
     fields.update({
@@ -119,7 +149,7 @@ def _job_log_fields(job=None, **extra):
             "download_attempt": job.get("download_attempts", 0),
             "delivery_attempt": job.get("delivery_attempts", 0),
         })
-        if job.get("bi_url"):
+        if job.get("bi_url") and should_log_bi_instance():
             fields["bi_instance"] = bi_instance_label(job["bi_url"])
     fields.update({k: v for k, v in extra.items() if v is not None and v != ""})
     return fields

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -15,6 +15,7 @@ from bi_export_shared import (
     MAX_EXPORT_ATTEMPTS,
     STALE_REQUEST_AGE,
     bi_get_export_queue,
+    bi_instance_label,
     bi_resolve_export_target,
     get_session,
     job_tag,
@@ -63,7 +64,11 @@ def _prepare_export(req, tag):
     try:
         known_paths = {item.get("path") for item in bi_get_export_queue(sess, req["bi_url"], sid) if item.get("path")}
     except Exception as exc:
-        logger.warning(f"{tag} Failed to read export queue before enqueue: {safe_error_summary(exc)}")
+        logger.warning(
+            f"{tag} Failed to read export queue before enqueue | "
+            f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_snapshot "
+            f"error_code=queue_snapshot_failed error={safe_error_summary(exc)}"
+        )
 
     target_path = None
     relative_uri = None
@@ -77,12 +82,20 @@ def _prepare_export(req, tag):
                     queue_data = bi_get_export_queue(sess, req["bi_url"], sid)
                     target_path, relative_uri = bi_resolve_export_target(queue_data, known_paths, tag)
                 except Exception as exc:
-                    logger.warning(f"{tag} Failed to refresh export queue after enqueue: {safe_error_summary(exc)}")
+                    logger.warning(
+                        f"{tag} Failed to refresh export queue after enqueue | "
+                        f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_snapshot_refresh "
+                        f"error_code=queue_refresh_failed error={safe_error_summary(exc)}"
+                    )
             if target_path and relative_uri:
                 break
 
         if "OpenBVR failed" in str(res.get("data", {})) and export_attempt == 0:
-            logger.warning(f"{tag} BI reported OpenBVR failed. Retrying in 2s...")
+            logger.warning(
+                f"{tag} BI reported OpenBVR failed. Retrying in 2s... | "
+                f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_submit "
+                f"error_code=openbvr_failed"
+            )
             time.sleep(2)
             continue
 
@@ -151,6 +164,7 @@ def _process_request(raw):
         f"{tag} export submitted",
         job,
         logger=logger,
+        phase="export_submitted",
         target_path=job["target_path"],
         relative_uri=job["relative_uri"],
         queue="bi:export:requests",

--- a/app/bi_queue_monitor.py
+++ b/app/bi_queue_monitor.py
@@ -15,6 +15,7 @@ from bi_export_shared import (
     MAX_EXPORT_ATTEMPTS,
     MAX_RECOVERY_ATTEMPTS,
     QUEUE_PROGRESS_LOG_INTERVAL,
+    bi_instance_label,
     bi_get_export_queue,
     get_session,
     job_tag,
@@ -87,7 +88,8 @@ def _poll_active_exports():
             active_exports = bi_get_export_queue(sess, bi_url, sid)
         except Exception as exc:
             logger.warning(
-                f"{tag} export queue poll failed | bi_url={bi_url} error={safe_error_summary(exc)}"
+                f"{tag} export queue poll failed | bi_instance={bi_instance_label(bi_url)} "
+                f"phase=queue_poll error_code=queue_poll_failed error={safe_error_summary(exc)}"
             )
             continue
 
@@ -107,6 +109,7 @@ def _poll_active_exports():
                         f"{tag} export acknowledged",
                         job,
                         logger=logger,
+                        phase="queue_ack",
                         queue_size=queue_size,
                         target_path=job["target_path"],
                     )
@@ -117,6 +120,7 @@ def _poll_active_exports():
                         f"{tag} export in progress",
                         job,
                         logger=logger,
+                        phase="queue_progress",
                         elapsed=f"{elapsed:.1f}s",
                         queue_size=queue_size,
                         active_exports=len(request_ids),
@@ -139,6 +143,7 @@ def _poll_active_exports():
                     f"{tag} export ready for download",
                     job,
                     logger=logger,
+                    phase="ready_for_download",
                     elapsed=f"{elapsed:.1f}s",
                     queue_size=queue_size,
                     download_queue_depth=r.llen(DOWNLOAD_REQUEST_QUEUE),
@@ -152,8 +157,10 @@ def _poll_active_exports():
                         f"{tag} export acknowledgement timeout; retrying",
                         job,
                         logger=logger,
+                        phase="queue_ack_timeout",
                         elapsed=f"{elapsed:.1f}s",
                         queue_size=queue_size,
+                        error_code="queue_ack_timeout",
                     )
                     queue_retry(job, "export not acknowledged by queue monitor")
                 else:
@@ -180,8 +187,10 @@ def _poll_active_exports():
                         f"{tag} export queue timeout; retrying after recovery",
                         job,
                         logger=logger,
+                        phase="queue_timeout",
                         elapsed=f"{elapsed:.1f}s",
                         queue_size=queue_size,
+                        error_code="queue_timeout",
                     )
                     job["request"]["_recovery_attempts"] = job.get("recovery_attempts", 0) + 1
                     queue_retry(job, "timed out waiting for BI queue")
@@ -196,8 +205,10 @@ def _poll_active_exports():
                         f"{tag} export failed waiting for queue",
                         job,
                         logger=logger,
+                        phase="queue_failed",
                         elapsed=f"{elapsed:.1f}s",
                         queue_size=queue_size,
+                        error_code="queue_timeout",
                     )
 
 

--- a/app/bi_watchdog.py
+++ b/app/bi_watchdog.py
@@ -53,7 +53,14 @@ def _repair_job(job):
     transition_age = now - float(job.get("last_transition_at", job.get("updated_at", now)))
 
     if status in {"submitted", "queued"} and not r.sismember(ACTIVE_EXPORT_SET, request_id):
-        log_job_event(logging.WARNING, f"{tag} watchdog reattaching active export", job, logger=logger)
+        log_job_event(
+            logging.WARNING,
+            f"{tag} watchdog reattaching active export",
+            job,
+            logger=logger,
+            phase="watchdog_reattach",
+            error_code="active_export_missing",
+        )
         r.sadd(ACTIVE_EXPORT_SET, request_id)
         job["next_poll_at"] = 0
         job["last_transition_at"] = now
@@ -67,7 +74,9 @@ def _repair_job(job):
                 f"{tag} watchdog retrying unacknowledged export",
                 job,
                 logger=logger,
+                phase="watchdog_export_retry",
                 age=f"{submitted_age:.1f}s",
+                error_code="queue_ack_timeout",
             )
             queue_retry(job, "watchdog: export acknowledgement stale")
         else:
@@ -86,7 +95,9 @@ def _repair_job(job):
                 f"{tag} watchdog retrying stale queued export",
                 job,
                 logger=logger,
+                phase="watchdog_queue_retry",
                 age=f"{submitted_age:.1f}s",
+                error_code="queue_timeout",
             )
             queue_retry(job, "watchdog: export queue stale")
         else:
@@ -104,8 +115,10 @@ def _repair_job(job):
             f"{tag} watchdog requeueing stale ready download",
             job,
             logger=logger,
+            phase="watchdog_download_requeue",
             age=f"{transition_age:.1f}s",
             download_queue_depth=r.llen(DOWNLOAD_REQUEST_QUEUE),
+            error_code="download_stale",
         )
         job["last_transition_at"] = now
         save_job(job)
@@ -118,7 +131,9 @@ def _repair_job(job):
             f"{tag} watchdog requeueing stalled export retry",
             job,
             logger=logger,
+            phase="watchdog_retry_requeue",
             age=f"{transition_age:.1f}s",
+            error_code="retry_queue_stale",
         )
         job["last_transition_at"] = now
         save_job(job)
@@ -133,8 +148,10 @@ def _repair_job(job):
                     f"{tag} watchdog requeueing stale delivery job",
                     job,
                     logger=logger,
+                    phase="watchdog_delivery_requeue",
                     age=f"{transition_age:.1f}s",
                     delivery_queue_depth=r.llen(VIDEO_DELIVERY_QUEUE),
+                    error_code="delivery_queue_stale",
                 )
                 mark_delivery_queued(job)
                 return
@@ -146,7 +163,9 @@ def _repair_job(job):
                         f"{tag} watchdog requeueing stuck delivery processing",
                         job,
                         logger=logger,
+                        phase="watchdog_delivery_processing_requeue",
                         age=f"{transition_age:.1f}s",
+                        error_code="delivery_processing_stale",
                     )
                     mark_delivery_queued(job)
                 else:

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -34,6 +34,24 @@ logger.addHandler(handler)
 def _resolve_logger(service_logger=None):
     return service_logger or logging
 
+
+def _format_log_fields(**fields):
+    ordered = []
+    for key in sorted(fields):
+        value = fields[key]
+        if value is None or value == "":
+            continue
+        ordered.append(f"{key}={value}")
+    return " ".join(ordered)
+
+
+def log_alert_event(level, tag, message, phase, error_code=None, **extra):
+    suffix = _format_log_fields(phase=phase, error_code=error_code, **extra)
+    line = f"{tag} {message}"
+    if suffix:
+        line = f"{line} | {suffix}"
+    logging.log(level, line)
+
 # --- REDIS ---
 redis_url = os.getenv('REDIS_URL', 'redis://redis:6379/0')
 r = redis.from_url(redis_url)
@@ -677,29 +695,92 @@ def build_bi_export_payload(config, output_path, tag, delivery_context=None):
             )
             if result is not None:
                 clip_path, offset, duration = result
-                logging.info(f"{tag} Pre-queue alert resolved: clip={clip_path}")
+                log_alert_event(
+                    logging.INFO,
+                    tag,
+                    "Pre-queue alert resolved",
+                    "prequeue_lookup",
+                    bi_instance=config["bi_url"],
+                    lookup_result="resolved",
+                    clip_path=clip_path,
+                    offset=offset,
+                    duration=duration,
+                )
             elif bvr_clip:
                 clip_path = bvr_clip
                 offset = _parse_offset_ms(trigger_filename)
                 duration = 30000
                 if offset is not None:
-                    logging.info(f"{tag} Alert not in alertlist — bvr fallback: clip={clip_path} offset={offset}")
+                    log_alert_event(
+                        logging.INFO,
+                        tag,
+                        "Alert not in alertlist; using bvr fallback",
+                        "prequeue_lookup",
+                        bi_instance=config["bi_url"],
+                        lookup_result="bvr_fallback",
+                        clip_path=clip_path,
+                        offset=offset,
+                        duration=duration,
+                    )
                 else:
-                    logging.warning(f"{tag} Alert not in alertlist and offset unparseable — skipping export")
+                    log_alert_event(
+                        logging.WARNING,
+                        tag,
+                        "Alert not in alertlist and offset unparseable; skipping export",
+                        "prequeue_lookup",
+                        error_code="offset_unparseable",
+                        bi_instance=config["bi_url"],
+                        lookup_result="skipped",
+                        clip_path=clip_path,
+                    )
                     return None
             else:
-                logging.warning(f"{tag} Alert not in BI alertlist at queue time -- skipping export")
+                log_alert_event(
+                    logging.WARNING,
+                    tag,
+                    "Alert not in BI alertlist at queue time; skipping export",
+                    "prequeue_lookup",
+                    error_code="alert_not_found",
+                    bi_instance=config["bi_url"],
+                    lookup_result="skipped",
+                )
                 return None
         except Exception as e:
-            logging.warning(f"{tag} Pre-queue BI lookup failed ({e})")
+            log_alert_event(
+                logging.WARNING,
+                tag,
+                "Pre-queue BI lookup failed",
+                "prequeue_lookup",
+                error_code="lookup_failed",
+                bi_instance=config.get("bi_url"),
+                error=_safe_request_error(e),
+            )
             if bvr_clip:
                 clip_path = bvr_clip
                 offset = _parse_offset_ms(trigger_filename)
                 duration = 30000
                 if offset is not None:
-                    logging.info(f"{tag} Using bvr fallback after lookup error: clip={clip_path} offset={offset}")
+                    log_alert_event(
+                        logging.INFO,
+                        tag,
+                        "Using bvr fallback after lookup error",
+                        "prequeue_lookup",
+                        bi_instance=config["bi_url"],
+                        lookup_result="bvr_fallback_after_error",
+                        clip_path=clip_path,
+                        offset=offset,
+                        duration=duration,
+                    )
                 else:
-                    logging.warning(f"{tag} bvr fallback unavailable (offset unparseable) -- queuing anyway")
+                    log_alert_event(
+                        logging.WARNING,
+                        tag,
+                        "bvr fallback unavailable (offset unparseable); queuing anyway",
+                        "prequeue_lookup",
+                        error_code="offset_unparseable",
+                        bi_instance=config.get("bi_url"),
+                        lookup_result="queue_without_clip",
+                    )
 
     return {
         "request_id":       request_id,
@@ -729,7 +810,13 @@ def queue_bi_export(config, output_path, tag, delivery_context=None):
 
     request_id = payload["request_id"]
     r.rpush(EXPORT_REQUEST_QUEUE, json.dumps(payload))
-    logging.info(f"{tag} BI export request queued")
+    log_alert_event(
+        logging.INFO,
+        tag,
+        "BI export request queued",
+        "export_request_queued",
+        queue=EXPORT_REQUEST_QUEUE,
+    )
     return request_id
 
 
@@ -768,14 +855,18 @@ def process_alert(image_path, config):
     tag = f"[{config['name']}][{req_id}]"
     raw_mp4 = None
     optimised_mp4 = None
+    final_status = "unknown"
+    summary_error_code = None
     try:
-        logging.info(f"{tag} Processing alert...")
+        log_alert_event(logging.INFO, tag, "Processing alert...", "alert_processing_started")
 
         if is_muted(config):
-            logging.info(f"{tag} Muted — skipping.")
+            final_status = "muted"
+            log_alert_event(logging.INFO, tag, "Muted; skipping.", "alert_skipped", final_status=final_status)
             return
 
         if check_auto_mute(config):
+            final_status = "auto_muted"
             send_auto_mute_notification(config)
             return
 
@@ -826,16 +917,55 @@ def process_alert(image_path, config):
                 request_id = queue_bi_export(config, raw_mp4, tag, delivery_context=delivery_context)
 
                 if not request_id:
-                    logging.warning(f"{tag} Video export failed, keeping photo.")
+                    final_status = "photo_only"
+                    summary_error_code = "video_export_unavailable"
+                    log_alert_event(
+                        logging.WARNING,
+                        tag,
+                        "Video export failed, keeping photo.",
+                        "video_queue_result",
+                        error_code=summary_error_code,
+                        final_status=final_status,
+                    )
                 else:
-                    logging.info(f"{tag} Video export queued for asynchronous delivery")
+                    final_status = "still_sent_video_queued"
+                    log_alert_event(
+                        logging.INFO,
+                        tag,
+                        "Video export queued for asynchronous delivery",
+                        "video_queue_result",
+                        final_status=final_status,
+                    )
                     raw_mp4 = None
             else:
-                logging.warning(f"{tag} Send video enabled but BI credentials missing.")
+                final_status = "photo_only"
+                summary_error_code = "bi_credentials_missing"
+                log_alert_event(
+                    logging.WARNING,
+                    tag,
+                    "Send video enabled but BI credentials missing.",
+                    "video_queue_result",
+                    error_code=summary_error_code,
+                    final_status=final_status,
+                )
+        elif final_status == "unknown":
+            final_status = "photo_only"
 
     except Exception as e:
-        logging.error(f"{tag} Task failed: {e}")
+        final_status = "task_failed"
+        summary_error_code = "task_exception"
+        logging.error(f"{tag} Task failed: {_safe_request_error(e)}")
     finally:
+        log_alert_event(
+            logging.INFO,
+            tag,
+            "Alert processing summary",
+            "alert_summary",
+            error_code=summary_error_code,
+            final_status=final_status,
+            send_video=config.get('send_video') == 1,
+            trigger_filename=bool(config.get('trigger_filename')),
+        )
         for p in [image_path, raw_mp4, optimised_mp4]:
             if p and os.path.exists(p):
                 os.remove(p)

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -66,9 +66,23 @@ def _process_delivery_request(request_id):
     job["delivery_status"] = "processing"
     job["last_transition_at"] = time.time()
     save_job(job)
-    log_job_event(logging.INFO, f"{tag} delivery processing started", job, logger=logger)
+    log_job_event(
+        logging.INFO,
+        f"{tag} delivery processing started",
+        job,
+        logger=logger,
+        phase="delivery_started",
+    )
 
     if not os.path.exists(raw_mp4):
+        log_job_event(
+            logging.ERROR,
+            f"{tag} delivery failed; downloaded video missing from disk",
+            job,
+            logger=logger,
+            phase="delivery_failed",
+            error_code="downloaded_video_missing",
+        )
         finish_delivery(job, False, "downloaded video missing from disk")
         return
 
@@ -82,9 +96,24 @@ def _process_delivery_request(request_id):
     )
     if not media_ok:
         if job["delivery_attempts"] < MAX_DELIVERY_ATTEMPTS:
-            log_job_event(logging.WARNING, f"{tag} telegram media replace failed; retrying", job)
+            log_job_event(
+                logging.WARNING,
+                f"{tag} telegram media replace failed; retrying",
+                job,
+                logger=logger,
+                phase="delivery_retry",
+                error_code="telegram_replace_failed",
+            )
             requeue_delivery(job, "telegram media replace failed")
         else:
+            log_job_event(
+                logging.ERROR,
+                f"{tag} telegram media replace failed",
+                job,
+                logger=logger,
+                phase="delivery_failed",
+                error_code="telegram_replace_failed",
+            )
             finish_delivery(job, False, "telegram media replace failed")
             _cleanup_paths(optimised_mp4, raw_mp4)
         return
@@ -99,7 +128,14 @@ def _process_delivery_request(request_id):
 
     _cleanup_paths(optimised_mp4, raw_mp4)
     finish_delivery(load_job(request_id) or job, True, None)
-    log_job_event(logging.INFO, f"{tag} delivery completed", load_job(request_id) or job, logger=logger)
+    log_job_event(
+        logging.INFO,
+        f"{tag} delivery completed",
+        load_job(request_id) or job,
+        logger=logger,
+        phase="delivery_completed",
+        final_status="video_delivered",
+    )
 
 
 def run_video_delivery_worker():

--- a/app/worker.py
+++ b/app/worker.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import redis
 from rq import Worker, Queue
 
@@ -8,10 +9,13 @@ redis_url = os.getenv('REDIS_URL', 'redis://redis:6379/0')
 # Establish connection
 conn = redis.from_url(redis_url)
 
+for name in ["rq.worker", "rq.job", "rq.queue"]:
+    logging.getLogger(name).setLevel(logging.WARNING)
+
 if __name__ == '__main__':
     # Fix: Explicitly create Queues with the connection
     queues = [Queue(name, connection=conn) for name in listen]
     
     # Start the worker
     worker = Worker(queues, connection=conn)
-    worker.work()
+    worker.work(logging_level="WARNING")

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -472,7 +472,10 @@ HTML_TEMPLATE = r"""
         <div class="tab-pane fade" id="logs-pane">
             <div class="d-flex justify-content-between mb-2">
                 <h5>Live Logs (last 200 lines)</h5>
-                <div>
+                <div class="d-flex align-items-center gap-2">
+                    <select id="logSourceFilter" class="form-select form-select-sm" style="width:auto;">
+                        <option value="all">All sources</option>
+                    </select>
                     <a href="{{ url_for('index') }}" class="btn btn-sm btn-outline-secondary">🔄 Refresh</a>
                     <form action="{{ url_for('clear_logs') }}" method="POST" style="display:inline;">
                         <button class="btn btn-sm btn-outline-danger">🗑️ Clear</button>
@@ -664,7 +667,34 @@ const colors = [
     '#afeeee', '#ee82ee', '#98fb98'
 ];
 function stringToColor(s){let h=0;for(let i=0;i<s.length;i++){h=s.charCodeAt(i)+((h<<5)-h);}return colors[Math.abs(h)%colors.length];}
-function colorizeLogs(){const v=document.getElementById('logViewer');if(!v)return;const lines=v.innerText.split('\n');let html='';lines.forEach(l=>{if(!l.trim())return;const matches=[...l.matchAll(/\[([^\]]+)\]/g)];const key=matches.length?matches[matches.length-1][1]:'';html+=`<div style="color:${key?stringToColor(key):'#888'}">${l}</div>`;});v.innerHTML=html;v.scrollTop=v.scrollHeight;}
+function escapeHtml(s){return s.replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');}
+function logSource(line){const match=line.match(/^\[([^\]]+)\]/);return match?match[1]:'unknown';}
+function populateLogSourceFilter(lines){
+    const select=document.getElementById('logSourceFilter');
+    if(!select)return;
+    const current=select.value||'all';
+    const sources=[...new Set(lines.map(logSource).filter(Boolean))].sort();
+    select.innerHTML='<option value="all">All sources</option>'+sources.map(s=>`<option value="${s}">${s}</option>`).join('');
+    select.value=sources.includes(current)||current==='all'?current:'all';
+}
+function renderLogs(){
+    const v=document.getElementById('logViewer');
+    if(!v)return;
+    if(!v.dataset.rawLogs){v.dataset.rawLogs=v.innerText;}
+    const lines=v.dataset.rawLogs.split('\n').filter(l=>l.trim());
+    populateLogSourceFilter(lines);
+    const selected=(document.getElementById('logSourceFilter')||{}).value||'all';
+    let html='';
+    lines.forEach(l=>{
+        const source=logSource(l);
+        if(selected!=='all'&&source!==selected)return;
+        const matches=[...l.matchAll(/\[([^\]]+)\]/g)];
+        const key=matches.length?matches[matches.length-1][1]:'';
+        html+=`<div data-source="${source}" style="color:${key?stringToColor(key):'#888'}">${escapeHtml(l)}</div>`;
+    });
+    v.innerHTML=html;
+    v.scrollTop=v.scrollHeight;
+}
 const html=document.documentElement;
 function setTheme(t){html.setAttribute('data-bs-theme',t);localStorage.setItem('theme',t);document.getElementById('themeIcon').innerText=t==='dark'?'☀️':'🌙';}
 function toggleTheme(){setTheme(html.getAttribute('data-bs-theme')==='dark'?'light':'dark');}
@@ -699,7 +729,9 @@ document.addEventListener('DOMContentLoaded',()=>{
     if(savedTab){const t=document.querySelector(`[data-bs-target="${savedTab}"]`);if(t)new bootstrap.Tab(t).show();}
     document.querySelectorAll('[data-bs-toggle="tab"]').forEach(el=>el.addEventListener('click',e=>localStorage.setItem('activeTab',e.target.getAttribute('data-bs-target'))));
     document.querySelector('[data-bs-target="#logs-pane"]').addEventListener('shown.bs.tab',()=>{const v=document.getElementById('logViewer');if(v)v.scrollTop=v.scrollHeight;});
-    colorizeLogs();
+    const logSourceFilter=document.getElementById('logSourceFilter');
+    if(logSourceFilter)logSourceFilter.addEventListener('change',renderLogs);
+    renderLogs();
     function relativeTime(ts){const diff=Math.floor((Date.now()-new Date(ts.replace(' ','T')))/1000);if(diff<60)return diff+'s ago';if(diff<3600)return Math.floor(diff/60)+'m ago';if(diff<86400)return Math.floor(diff/3600)+'h ago';return Math.floor(diff/86400)+'d ago';}
     document.querySelectorAll('.last-seen[data-ts]').forEach(el=>{el.textContent='Last triggered: '+relativeTime(el.dataset.ts);el.title=el.dataset.ts;});
     fetch('/api/check-update').then(r=>r.json()).then(d=>{

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -263,7 +263,7 @@ class TestDownloader:
             "recovery_attempts": 0,
         }
         bi_export_shared.save_job(job)
-        monkeypatch.setattr(bi_downloader, "_download_export", lambda current_job: (True, None))
+        monkeypatch.setattr(bi_downloader, "_download_export", lambda current_job: (True, None, 1.2, 2048))
 
         bi_downloader._process_download_request(job["request_id"])
 
@@ -295,7 +295,7 @@ class TestDownloader:
             "delivery_attempts": 0,
         }
         bi_export_shared.save_job(job)
-        monkeypatch.setattr(bi_downloader, "_download_export", lambda current_job: (True, None))
+        monkeypatch.setattr(bi_downloader, "_download_export", lambda current_job: (True, None, 1.2, 2048))
 
         bi_downloader._process_download_request(job["request_id"])
 
@@ -327,7 +327,7 @@ class TestDownloader:
         monkeypatch.setattr(
             bi_downloader,
             "_download_export",
-            lambda current_job: (False, "download failed (file not ready)"),
+            lambda current_job: (False, "download failed (file not ready)", None, None),
         )
         monkeypatch.setattr(bi_downloader, "trigger_bi_recovery", lambda *args, **kwargs: True)
 


### PR DESCRIPTION
  ## Summary
  - add explicit `phase` fields across BI exporter, queue monitor, downloader, watchdog, and delivery worker logs
  - add structured `error_code` fields for the main timeout, retry, download, and delivery failure paths
  - include a `bi_instance` label in BI lifecycle logs so multi-BI setups are easier to debug
  - add structured pre-export BI lookup logs in `app/tasks.py`
  - add a final per-alert summary line in `system.log` with `final_status`
  - reduce noisy RQ worker boilerplate in `system.log`
  - improve downloader log semantics so completed downloads log after the job transitions to `downloaded`
  - add a log source filter in the web UI Logs tab while keeping aggregated multi-file log viewing

  ## Problem
  The staged BI pipeline logs had become much better, but diagnosing failures still required reading free-text messages closely and mentally stitching together states across services.

  There were still a few practical gaps:
  - no explicit `phase` field for BI lifecycle events
  - failure logs were not normalized with machine-readable error codes
  - BI instance identity was not surfaced consistently
  - pre-export BI lookup results in `system.log` were still mostly free-text
  - `system.log` lacked a single final per-alert summary outcome
  - the Logs tab aggregated all files, but did not allow filtering by source
  - RQ worker boilerplate still added noise to pasted logs

  ## What Changed
  ### BI service logs
  Updated:
  - `app/bi_exporter.py`
  - `app/bi_queue_monitor.py`
  - `app/bi_downloader.py`
  - `app/bi_watchdog.py`
  - `app/video_delivery_worker.py`

  These logs now include:
  - `phase`
  - `error_code` where relevant
  - `bi_instance`
  - clearer download/delivery state transitions

  ### Alert-side logs
  Updated `app/tasks.py` to:
  - log BI pre-export lookup results structurally
  - emit a final `alert_summary` line with `final_status`

  ### Worker logging
  Updated `app/worker.py` to suppress low-value RQ framework chatter so `system.log` is easier to scan.

  ### Web UI logs
  Updated `app/wsgi.py` so the Logs tab now includes a source filter for aggregated logs, allowing operators to isolate:
  - `system.log`
  - `bi_exporter.log`
  - `bi_queue_monitor.log`
  - `bi_downloader.log`
  - `bi_watchdog.log`
  - `video_delivery_worker.log`
  - `mute_bot.log`

  ## Expected Behavior
  - pasted logs should now be materially easier to analyze end-to-end
  - BI lifecycle progression is easier to grep by `phase`
  - failure reasons are easier to identify by `error_code`
  - multi-BI deployments are easier to distinguish with `bi_instance`
  - the final alert outcome is visible in one summary line
  - operators can filter the Logs tab by source file instead of scanning the full aggregate
