### PR TITLE
Add terminal video-delivery diagnosis logs with recommended actions

### DIFF
--- a/app/bi_downloader.py
+++ b/app/bi_downloader.py
@@ -17,6 +17,7 @@ from bi_export_shared import (
     get_session,
     job_tag,
     log_job_event,
+    log_terminal_diagnosis,
     load_job,
     mark_delivery_queued,
     r,
@@ -168,6 +169,14 @@ def _process_download_request(request_id):
         phase="download_failed",
         error=error_msg,
         error_code="download_not_ready",
+    )
+    log_terminal_diagnosis(
+        logger,
+        tag,
+        job,
+        "download_failed",
+        "download_not_ready",
+        error=error_msg,
     )
     finish_job(job, False, error_msg)
 

--- a/app/bi_export_shared.py
+++ b/app/bi_export_shared.py
@@ -173,6 +173,55 @@ def log_job_event(level, message, job=None, logger=None, **extra):
     logger.log(level, line)
 
 
+def recommended_action_for(error_code):
+    actions = {
+        "active_export_missing": "check_queue_monitor_and_redis_active_export_membership",
+        "alert_not_found": "check_bi_alertlist_retention_and_trigger_filename_mapping",
+        "bi_credentials_missing": "check_blue_iris_credentials_in_camera_config",
+        "bi_login_failed": "check_bi_url_credentials_and_session_reuse",
+        "delivery_processing_stale": "check_video_delivery_worker_health_and_ffmpeg_runtime",
+        "delivery_queue_stale": "check_video_delivery_worker_queue_consumption_and_tmp_images_sharing",
+        "download_attempt_failed": "check_bi_clip_endpoint_and_network_stability",
+        "download_not_ready": "check_bi_export_completion_and_clip_readiness",
+        "download_stale": "check_bi_downloader_health_and_download_queue_backlog",
+        "downloaded_video_missing": "check_tmp_images_volume_sharing_and_cleanup_timing",
+        "export_command_failed": "check_bi_export_api_response_and_clip_source_path",
+        "lookup_failed": "check_bi_alertlist_access_and_shared_session_reuse",
+        "missing_delivery_context": "check_telegram_message_context_persistence_before_queueing_export",
+        "missing_export_target": "check_bi_export_queue_response_and_target_resolution",
+        "missing_clip_path": "check_prequeue_lookup_and_bvr_clip_fallback",
+        "offset_unparseable": "check_alert_filename_format_and_offset_parser",
+        "openbvr_failed": "check_blue_iris_clip_integrity_and_source_bvr_path",
+        "persistent_404": "check_bi_clip_endpoint_visibility_after_export_completion",
+        "queue_ack_timeout": "check_bi_export_queue_acknowledgement_and_export_submission",
+        "queue_poll_failed": "check_bi_queue_monitor_connectivity_and_session_validity",
+        "queue_refresh_failed": "check_bi_export_queue_refresh_after_submit",
+        "queue_snapshot_failed": "check_bi_export_queue_snapshot_before_submit",
+        "queue_timeout": "check_bi_export_queue_progress_and_encoder_health",
+        "retry_queue_stale": "check_export_retry_requeue_and_exporter_consumer_health",
+        "stale_request": "check_queue_latency_and_alert_enqueue_timing",
+        "task_exception": "check_system_log_for_preceding_task_failure_details",
+        "telegram_replace_failed": "check_telegram_media_replace_api_and_message_permissions",
+        "retry_limit_reached": "check_repeated_export_failures_and_prior_error_codes",
+        "video_export_unavailable": "check_prequeue_lookup_result_and_export_request_enqueue",
+    }
+    return actions.get(error_code)
+
+
+def log_terminal_diagnosis(logger, tag, job, phase, error_code, final_status="video_not_delivered", **extra):
+    log_job_event(
+        logging.ERROR,
+        f"{tag} terminal diagnosis",
+        job,
+        logger=logger,
+        phase=phase,
+        error_code=error_code,
+        final_status=final_status,
+        recommended_action=recommended_action_for(error_code),
+        **extra,
+    )
+
+
 def session_key(bi_url, bi_user):
     digest = hashlib.sha256(f"{bi_url}|{bi_user}".encode("utf-8")).hexdigest()
     return f"{SESSION_KEY_PREFIX}{digest}"

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -20,6 +20,7 @@ from bi_export_shared import (
     get_session,
     job_tag,
     log_job_event,
+    log_terminal_diagnosis,
     r,
     safe_error_summary,
     save_job,
@@ -145,15 +146,46 @@ def _process_request(raw):
     tag = job_tag(req)
     queued_at = req.get("queued_at", 0)
     if queued_at and (time.time() - queued_at) > STALE_REQUEST_AGE:
+        log_terminal_diagnosis(
+            logger,
+            tag,
+            req,
+            "export_rejected",
+            "stale_request",
+            error="stale request",
+        )
         write_result(request_id, req.get("output_path"), False, "stale request")
         return
 
     if int(req.get("_export_attempts", 0)) >= MAX_EXPORT_ATTEMPTS:
+        log_terminal_diagnosis(
+            logger,
+            tag,
+            req,
+            "export_rejected",
+            "retry_limit_reached",
+            error="export retry limit reached",
+        )
         write_result(request_id, req.get("output_path"), False, "export retry limit reached")
         return
 
     job, error_msg = _prepare_export(req, tag)
     if not job:
+        error_code = "export_command_failed"
+        if error_msg == "BI login failed":
+            error_code = "bi_login_failed"
+        elif error_msg == "missing clip_path for staged export":
+            error_code = "missing_clip_path"
+        elif error_msg == "missing path/uri in BI response":
+            error_code = "missing_export_target"
+        log_terminal_diagnosis(
+            logger,
+            tag,
+            req,
+            "export_submit_failed",
+            error_code,
+            error=error_msg,
+        )
         write_result(request_id, req.get("output_path"), False, error_msg)
         return
 

--- a/app/bi_queue_monitor.py
+++ b/app/bi_queue_monitor.py
@@ -20,6 +20,7 @@ from bi_export_shared import (
     get_session,
     job_tag,
     log_job_event,
+    log_terminal_diagnosis,
     load_job,
     queue_poll_interval,
     r,
@@ -81,6 +82,14 @@ def _poll_active_exports():
                     job["error"] = "BI login failed"
                     save_job(job)
                     r.srem(ACTIVE_EXPORT_SET, job["request_id"])
+                    log_terminal_diagnosis(
+                        logger,
+                        job_tag(job),
+                        job,
+                        "queue_failed",
+                        "bi_login_failed",
+                        error="BI login failed",
+                    )
                     write_result(job["request_id"], job["output_path"], False, "BI login failed")
             continue
 
@@ -168,6 +177,15 @@ def _poll_active_exports():
                     job["error"] = "export not acknowledged by queue monitor"
                     save_job(job)
                     r.srem(ACTIVE_EXPORT_SET, job["request_id"])
+                    log_terminal_diagnosis(
+                        logger,
+                        tag,
+                        job,
+                        "queue_failed",
+                        "queue_ack_timeout",
+                        elapsed=f"{elapsed:.1f}s",
+                        error="export not acknowledged by queue monitor",
+                    )
                     write_result(
                         job["request_id"],
                         job["output_path"],
@@ -199,6 +217,15 @@ def _poll_active_exports():
                     job["error"] = "timed out waiting for BI queue"
                     save_job(job)
                     r.srem(ACTIVE_EXPORT_SET, job["request_id"])
+                    log_terminal_diagnosis(
+                        logger,
+                        tag,
+                        job,
+                        "queue_failed",
+                        "queue_timeout",
+                        elapsed=f"{elapsed:.1f}s",
+                        error="timed out waiting for BI queue",
+                    )
                     write_result(job["request_id"], job["output_path"], False, "timed out waiting for BI queue")
                     log_job_event(
                         logging.ERROR,

--- a/app/bi_watchdog.py
+++ b/app/bi_watchdog.py
@@ -25,6 +25,7 @@ from bi_export_shared import (
     iter_job_ids,
     job_tag,
     log_job_event,
+    log_terminal_diagnosis,
     load_job,
     mark_delivery_queued,
     queue_retry,
@@ -85,6 +86,15 @@ def _repair_job(job):
             job["last_transition_at"] = now
             save_job(job)
             r.srem(ACTIVE_EXPORT_SET, request_id)
+            log_terminal_diagnosis(
+                logger,
+                tag,
+                job,
+                "watchdog_failed",
+                "queue_ack_timeout",
+                age=f"{submitted_age:.1f}s",
+                error=job["error"],
+            )
             write_result(request_id, job["output_path"], False, job["error"])
         return
 
@@ -106,6 +116,15 @@ def _repair_job(job):
             job["last_transition_at"] = now
             save_job(job)
             r.srem(ACTIVE_EXPORT_SET, request_id)
+            log_terminal_diagnosis(
+                logger,
+                tag,
+                job,
+                "watchdog_failed",
+                "queue_timeout",
+                age=f"{submitted_age:.1f}s",
+                error=job["error"],
+            )
             write_result(request_id, job["output_path"], False, job["error"])
         return
 
@@ -169,6 +188,15 @@ def _repair_job(job):
                     )
                     mark_delivery_queued(job)
                 else:
+                    log_terminal_diagnosis(
+                        logger,
+                        tag,
+                        job,
+                        "delivery_failed",
+                        "delivery_processing_stale",
+                        age=f"{transition_age:.1f}s",
+                        error="watchdog: delivery processing stale",
+                    )
                     finish_delivery(job, False, "watchdog: delivery processing stale")
 
 

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -16,7 +16,7 @@ from urllib.parse import urljoin
 from logging.handlers import RotatingFileHandler
 from PIL import Image
 from datetime import datetime, timedelta
-from bi_export_shared import EXPORT_REQUEST_QUEUE, get_session
+from bi_export_shared import EXPORT_REQUEST_QUEUE, get_session, recommended_action_for
 
 # --- LOGGING SETUP ---
 LOG_FILE = os.getenv("LOG_FILE", "/app/logs/system.log")
@@ -963,6 +963,7 @@ def process_alert(image_path, config):
             "alert_summary",
             error_code=summary_error_code,
             final_status=final_status,
+            recommended_action=recommended_action_for(summary_error_code),
             send_video=config.get('send_video') == 1,
             trigger_filename=bool(config.get('trigger_filename')),
         )

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -13,6 +13,7 @@ from bi_export_shared import (
     finish_delivery,
     job_tag,
     log_job_event,
+    log_terminal_diagnosis,
     load_job,
     requeue_delivery,
     r,
@@ -55,6 +56,14 @@ def _process_delivery_request(request_id):
     delivery = job.get("delivery_context") or {}
     config = delivery.get("config") or {}
     if not config or "last_msg_id" not in config:
+        log_terminal_diagnosis(
+            logger,
+            job_tag(job),
+            job,
+            "delivery_failed",
+            "missing_delivery_context",
+            error="missing Telegram delivery context",
+        )
         finish_delivery(job, False, "missing Telegram delivery context")
         return
 
@@ -82,6 +91,14 @@ def _process_delivery_request(request_id):
             logger=logger,
             phase="delivery_failed",
             error_code="downloaded_video_missing",
+        )
+        log_terminal_diagnosis(
+            logger,
+            tag,
+            job,
+            "delivery_failed",
+            "downloaded_video_missing",
+            error="downloaded video missing from disk",
         )
         finish_delivery(job, False, "downloaded video missing from disk")
         return
@@ -113,6 +130,14 @@ def _process_delivery_request(request_id):
                 logger=logger,
                 phase="delivery_failed",
                 error_code="telegram_replace_failed",
+            )
+            log_terminal_diagnosis(
+                logger,
+                tag,
+                job,
+                "delivery_failed",
+                "telegram_replace_failed",
+                error="telegram media replace failed",
             )
             finish_delivery(job, False, "telegram media replace failed")
             _cleanup_paths(optimised_mp4, raw_mp4)


### PR DESCRIPTION
## Summary
  - add normalized terminal diagnosis logging for missed BI video deliveries
  - include `recommended_action` alongside `error_code` and `final_status` on terminal failure paths
  - centralize error-to-action mapping in shared BI pipeline helpers
  - extend alert summary logging so `system.log` also points to the likely next fix when an alert ends without video

  ## Problem
  The structured logging changes made it much easier to see where a BI video pipeline stopped, but they still did not always answer the two operator questions that matter most:

  1. Why did this alert not get its video?
  2. What should be checked or changed to prevent it next time?

  The logs showed the failing stage, but not a normalized final diagnosis or remediation hint.

  ## What Changed

  ### Shared diagnosis mapping
  Added shared diagnosis helpers in `app/bi_export_shared.py`:
  - `recommended_action_for(error_code)`
  - `log_terminal_diagnosis(...)`

  These provide a consistent mapping from failure type to an operator-facing next step.

  ### Terminal failure logging
  Added normalized terminal diagnosis lines to the main BI failure exits in:
  - `app/bi_exporter.py`
  - `app/bi_queue_monitor.py`
  - `app/bi_downloader.py`
  - `app/bi_watchdog.py`
  - `app/video_delivery_worker.py`

  These lines now include:
  - `final_status=video_not_delivered`
  - `phase`
  - `error_code`
  - `recommended_action`

  ### Alert summary improvements
  Updated `app/tasks.py` so the existing per-alert summary line in `system.log` also includes `recommended_action` when the alert finishes without a queued or delivered video.

  ## Expected Behavior
  When a Telegram alert does not get its video, the logs should now be able to answer both:
  - what failed
  - what to check next

  Example failure outcomes now point directly to likely fixes such as:
  - BI queue acknowledgement problems
  - BI download readiness issues
  - missing shared temp-file volume
  - Telegram media replacement failures
  - missing delivery context
  - stalled exporter/downloader/delivery workers
