### PR TITLE
[#74] Persist Redis state for staged BI export jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ docker compose up -d
 
 The web UI will be available at `http://your-host:5000`.
 
+Redis now stores durable BI export job state, session reuse data, and queue coordination. The default Compose file persists this in the named Docker volume `redis_data`, so do not remove that volume unless you intentionally want to discard in-flight BI pipeline state.
+
 ### 2. Add a camera configuration
 
 Open the web UI and click **+ New Configuration**. Fill in:
@@ -138,6 +140,19 @@ When a new version is released, the web UI shows an update banner. Run:
 docker compose pull
 docker compose up -d
 ```
+
+Do not run `docker compose down -v` unless you intentionally want to delete persisted Redis state, including staged BI export jobs.
+
+## Redis Persistence
+
+The staged BI export pipeline stores active export/download/delivery coordination in Redis. This is not just a transient cache anymore.
+
+The default `docker-compose.yml` now enables Redis append-only persistence and mounts a named Docker volume:
+
+- `redis_data:/data`
+- `redis-server --appendonly yes --appendfsync everysec`
+
+That means normal container restarts and `docker compose down` / `up -d` cycles keep BI pipeline state intact. If you remove Docker volumes, you also remove Redis state and may orphan in-flight BI jobs.
 
 ## Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,13 @@
 volumes:
   tmp_images:
+  redis_data:
 
 services:
   redis:
     image: redis:alpine
+    command: redis-server --appendonly yes --appendfsync everysec
+    volumes:
+      - redis_data:/data
     restart: unless-stopped
 
   web:


### PR DESCRIPTION
 ## Summary
  - persist Redis data in Docker using a named volume
  - enable Redis append-only persistence for staged BI export job state
  - document that Redis now holds durable BI pipeline coordination data
  - warn operators not to remove Redis volumes unless they intentionally want to discard in-flight BI job state

  ## Problem
  The staged BI export pipeline stores active export state, retry state, delivery coordination, session reuse state, and result keys in Redis.

  Without explicit Redis persistence, a Redis/container restart could discard that state and leave in-flight BI jobs orphaned.

  ## What Changed

  ### Docker Compose
  Updated `docker-compose.yml` to make Redis durable by default:
  - added named volume `redis_data`
  - mounted `redis_data:/data`
  - started Redis with:
    - `redis-server --appendonly yes --appendfsync everysec`

  This enables append-only persistence and keeps Redis data across normal container restarts and `docker compose down` / `up -d` cycles.

  ### Documentation
  Updated `README.md` to explain:
  - Redis is no longer just a disposable cache
  - it stores staged BI export/download/delivery coordination state
  - the default Compose file now persists Redis data
  - operators should not run `docker compose down -v` unless they intentionally want to delete BI pipeline state

  ## Expected Behavior
  - normal container restarts keep staged BI export state intact
  - Redis restarts are less likely to orphan in-flight BI jobs
  - operators have clearer guidance on safe deployment/update behavior
  - accidental loss of BI pipeline state is less likely during routine maintenance

  ## Notes
 - This PR changes deployment durability and documentation only. It does not change the BI pipeline logic itself.
- Resolves #74 