### PR TITLE
Harden container image and run app as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.14-slim
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y ffmpeg && \
+    apt-get install -y --no-install-recommends ffmpeg && \
+    useradd --create-home --uid 1000 --shell /usr/sbin/nologin appuser && \
+    install -d -o appuser -g appuser /app /app/data /app/logs /tmp_images && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -13,5 +14,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app /app
 ARG APP_VERSION=dev
 RUN echo "$APP_VERSION" > /app/VERSION
+
+RUN chown -R appuser:appuser /app /tmp_images
+
+USER appuser
 
 CMD ["python3"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,9 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY app /app
+COPY --chown=appuser:appuser app /app
 ARG APP_VERSION=dev
 RUN echo "$APP_VERSION" > /app/VERSION
-
-RUN chown -R appuser:appuser /app /tmp_images
 
 USER appuser
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The web UI will be available at `http://your-host:5000`.
 
 Redis now stores durable BI export job state, session reuse data, and queue coordination. The default Compose file persists this in the named Docker volume `redis_data`, so do not remove that volume unless you intentionally want to discard in-flight BI pipeline state.
 
+Containers now run as a dedicated non-root user (`uid 1000`). If you bind-mount host directories such as `./data` or `./logs`, ensure they are writable by that user on the host.
+
 ### 2. Add a camera configuration
 
 Open the web UI and click **+ New Configuration**. Fill in:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The web UI will be available at `http://your-host:5000`.
 
 Redis now stores durable BI export job state, session reuse data, and queue coordination. The default Compose file persists this in the named Docker volume `redis_data`, so do not remove that volume unless you intentionally want to discard in-flight BI pipeline state.
 
-Containers now run as a dedicated non-root user (`uid 1000`). If you bind-mount host directories such as `./data` or `./logs`, ensure they are writable by that user on the host.
+Containers now run as a dedicated non-root user (`uid 1000`). This improves runtime isolation, and the image also avoids `apt-get upgrade` in favor of a tighter, more reproducible build that should be kept current by regularly rebasing onto updated base images. If you bind-mount host directories such as `./data` or `./logs`, ensure they are writable by that user on the host.
 
 ### 2. Add a camera configuration
 


### PR DESCRIPTION
## Summary
  - harden the application image by removing `apt-get upgrade`
  - create a dedicated non-root runtime user (`uid 1000`)
  - ensure the image creates writable application paths before dropping privileges
  - run the container as `appuser` by default
  - document the required host filesystem permissions for bind-mounted directories

  ## What Changed
  ### Dockerfile
  Updated `Dockerfile` to:
  - remove `apt-get upgrade -y`
  - install `ffmpeg` with `--no-install-recommends`
  - create non-root user `appuser` (`uid 1000`)
  - create and own:
    - `/app`
    - `/app/data`
    - `/app/logs`
    - `/tmp_images`
  - switch runtime to:
    - `USER appuser`

  ### Documentation
  Updated `README.md` to note that containers now run as `uid 1000` and that bind-mounted host directories must be writable by that user.

  ## Important Deployment Note
  If you are bind-mounting `./data` and `./logs` from the host, this change is important:

  ```bash
  sudo chown -R 1000:1000 data logs
```

  Without that, the non-root container may fail to write:

  - configs.db
  - log files
  - plate image data

  ## Expected Behavior

  - containers no longer run as root by default
  - the image is more reproducible and slightly tighter
  - writable app paths remain usable under the dedicated non-root user
  - existing deployments using host bind mounts must ensure data and logs are writable by uid 1000

Resolves #75 
