### PR TITLE
Fix DVLA Vehicle Enquiry API endpoint path

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -172,7 +172,7 @@ _PLATE_RE = re.compile(
     r'|[A-Z][0-9]{1,3}\s?[A-Z]{3}'     # Prefix (1983-01): A123 BCD
     r'|[A-Z]{3}\s?[0-9]{1,3}[A-Z])\b'  # Suffix (1963-83): ABC 123D
 )
-_DVLA_URL = "https://driver-vehicle-licensing.api.gov.uk/vehicle-enquiries/v1/vehicles"
+_DVLA_URL = "https://driver-vehicle-licensing.api.gov.uk/vehicle-enquiry/v1/vehicles"
 
 
 def _save_plate_thumbnail(image_path, plate):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -189,3 +189,15 @@ def test_enrich_caption_uses_correct_dvla_endpoint(monkeypatch):
     assert captured["json"] == {"registrationNumber": "AB12CDE"}
     assert captured["timeout"] == 10
     assert "(Ford, Blue, 2019)" in caption
+
+
+def test_enrich_caption_without_plate_returns_original_text(monkeypatch):
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {})
+
+    caption = tasks.enrich_caption_with_dvla(
+        "Vehicle arrived on driveway",
+        {"name": "Driveway", "dvla_api_key": "test-key"},
+        tag="[Driveway][abc12345]",
+    )
+
+    assert caption == "Vehicle arrived on driveway"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -155,3 +155,37 @@ def test_process_alert_starts_bi_export_prep_before_still_send_finishes(tmp_path
     tasks.process_alert(str(image_path), config)
 
     assert enqueued["payload"]["delivery_context"]["config"]["last_msg_id"] == 321
+
+
+def test_enrich_caption_uses_correct_dvla_endpoint(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _DummyResponse(
+            status_code=200,
+            payload={
+                "make": "Ford",
+                "colour": "Blue",
+                "yearOfManufacture": 2019,
+            },
+        )
+
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {})
+    monkeypatch.setattr(tasks, "_audit_plate", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+
+    caption = tasks.enrich_caption_with_dvla(
+        "Vehicle AB12 CDE arrived",
+        {"name": "Driveway", "dvla_api_key": "test-key"},
+        tag="[Driveway][abc12345]",
+    )
+
+    assert captured["url"] == "https://driver-vehicle-licensing.api.gov.uk/vehicle-enquiry/v1/vehicles"
+    assert captured["headers"]["x-api-key"] == "test-key"
+    assert captured["json"] == {"registrationNumber": "AB12CDE"}
+    assert captured["timeout"] == 10
+    assert "(Ford, Blue, 2019)" in caption


### PR DESCRIPTION
Fixes #101 

Updates the DVLA Vehicle Enquiry Service endpoint in app/tasks.py from the incorrect `vehicle-enquiries` path to the documented `vehicle-enquiry` path, and adds a regression test to lock the request URL and payload.