### PR TITLE
Add structured Telegram message and caption lifecycle logging

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -52,6 +52,52 @@ def log_alert_event(level, tag, message, phase, error_code=None, **extra):
         line = f"{line} | {suffix}"
     logging.log(level, line)
 
+
+def _telegram_log_fields(config, text=None, caption_source=None, caption_changed=None, message_id=None):
+    fields = {}
+    if caption_source:
+        fields["caption_source"] = caption_source
+    if caption_changed is not None:
+        fields["caption_changed"] = str(bool(caption_changed)).lower()
+    if text is not None:
+        fields["caption_length"] = len(text)
+        if config.get("verbose_logging") == 1:
+            fields["caption_text"] = text
+    if message_id is not None:
+        fields["message_id"] = message_id
+    return fields
+
+
+def log_telegram_event(
+    level,
+    tag,
+    message,
+    phase,
+    config,
+    service_logger=None,
+    error_code=None,
+    text=None,
+    caption_source=None,
+    caption_changed=None,
+    message_id=None,
+):
+    log = _resolve_logger(service_logger)
+    suffix = _format_log_fields(
+        phase=phase,
+        error_code=error_code,
+        **_telegram_log_fields(
+            config,
+            text=text,
+            caption_source=caption_source,
+            caption_changed=caption_changed,
+            message_id=message_id,
+        ),
+    )
+    line = f"{tag} {message}"
+    if suffix:
+        line = f"{line} | {suffix}"
+    log.log(level, line)
+
 # --- REDIS ---
 redis_url = os.getenv('REDIS_URL', 'redis://redis:6379/0')
 r = redis.from_url(redis_url)
@@ -561,7 +607,7 @@ def _tg_thread(config):
     return str(t) if t else None
 
 
-def send_telegram(config, img_path, caption):
+def send_telegram(config, img_path, caption, service_logger=None):
     req_id = config.get('request_id', 'unknown')
     tag = f"[{config['name']}][{req_id}]"
 
@@ -577,16 +623,56 @@ def send_telegram(config, img_path, caption):
         with open(img_path, 'rb') as f:
             resp = requests.post(url, files={'photo': f}, data=data, timeout=15)
             if resp.ok:
-                config['last_msg_id'] = resp.json()['result']['message_id']
+                message_id = resp.json()['result']['message_id']
+                config['last_msg_id'] = message_id
+                log_telegram_event(
+                    logging.INFO,
+                    tag,
+                    "Telegram photo sent",
+                    "telegram_photo_sent",
+                    config,
+                    service_logger=service_logger,
+                    text=caption,
+                    caption_source="still",
+                    message_id=message_id,
+                )
             else:
-                logging.error(f"{tag} Telegram send error: {resp.text}")
-    except Exception as e:
-        logging.error(f"{tag} Telegram error: {e}")
+                log_telegram_event(
+                    logging.ERROR,
+                    tag,
+                    "Telegram photo send failed",
+                    "telegram_photo_send_failed",
+                    config,
+                    service_logger=service_logger,
+                    error_code="telegram_photo_send_failed",
+                )
+    except Exception:
+        log_telegram_event(
+            logging.ERROR,
+            tag,
+            "Telegram photo send error",
+            "telegram_photo_send_failed",
+            config,
+            service_logger=service_logger,
+            error_code="telegram_photo_send_failed",
+        )
 
 
-def update_telegram_caption(config, text, service_logger=None):
-    log = _resolve_logger(service_logger)
+def update_telegram_caption(config, text, service_logger=None, caption_source="unknown", previous_text=None):
     if 'last_msg_id' not in config:
+        req_id = config.get('request_id', 'unknown')
+        tag = f"[{config['name']}][{req_id}]"
+        log_telegram_event(
+            logging.WARNING,
+            tag,
+            "Telegram caption update skipped; message id missing",
+            "telegram_caption_update_skipped",
+            config,
+            service_logger=service_logger,
+            error_code="telegram_message_id_missing",
+            text=text,
+            caption_source=caption_source,
+        )
         return False
 
     req_id = config.get('request_id', 'unknown')
@@ -596,15 +682,65 @@ def update_telegram_caption(config, text, service_logger=None):
     chat_id = config['chat_id']
     data = {'chat_id': chat_id, 'message_id': config['last_msg_id'], 'caption': text}
     try:
+        log_telegram_event(
+            logging.INFO,
+            tag,
+            "Telegram caption update started",
+            "telegram_caption_update_started",
+            config,
+            service_logger=service_logger,
+            text=text,
+            caption_source=caption_source,
+            caption_changed=(previous_text != text) if previous_text is not None else None,
+            message_id=config['last_msg_id'],
+        )
         resp = requests.post(f"https://api.telegram.org/bot{token}/editMessageCaption", data=data, timeout=10)
-        return resp.ok
-    except Exception as e:
-        log.error(f"{tag} Caption update error: {e}")
+        if resp.ok:
+            log_telegram_event(
+                logging.INFO,
+                tag,
+                "Telegram caption updated",
+                "telegram_caption_updated",
+                config,
+                service_logger=service_logger,
+                text=text,
+                caption_source=caption_source,
+                caption_changed=(previous_text != text) if previous_text is not None else None,
+                message_id=config['last_msg_id'],
+            )
+            return True
+        log_telegram_event(
+            logging.ERROR,
+            tag,
+            "Telegram caption update failed",
+            "telegram_caption_update_failed",
+            config,
+            service_logger=service_logger,
+            error_code="telegram_caption_update_failed",
+            text=text,
+            caption_source=caption_source,
+            caption_changed=(previous_text != text) if previous_text is not None else None,
+            message_id=config['last_msg_id'],
+        )
+        return False
+    except Exception:
+        log_telegram_event(
+            logging.ERROR,
+            tag,
+            "Telegram caption update error",
+            "telegram_caption_update_failed",
+            config,
+            service_logger=service_logger,
+            error_code="telegram_caption_update_failed",
+            text=text,
+            caption_source=caption_source,
+            caption_changed=(previous_text != text) if previous_text is not None else None,
+            message_id=config['last_msg_id'],
+        )
         return False
 
 
 def replace_telegram_media(config, media_path, caption, service_logger=None):
-    log = _resolve_logger(service_logger)
     req_id = config.get('request_id', 'unknown')
     tag = f"[{config['name']}][{req_id}]"
 
@@ -615,18 +751,61 @@ def replace_telegram_media(config, media_path, caption, service_logger=None):
     media_json = json.dumps({"type": "animation", "media": "attach://media_file", "caption": caption})
     data = {'chat_id': chat_id, 'message_id': config['last_msg_id'], 'media': media_json}
     try:
+        log_telegram_event(
+            logging.INFO,
+            tag,
+            "Telegram media replace started",
+            "telegram_media_replace_started",
+            config,
+            service_logger=service_logger,
+            text=caption,
+            caption_source="video",
+            message_id=config['last_msg_id'],
+        )
         with open(media_path, 'rb') as f:
             resp = requests.post(
                 f"https://api.telegram.org/bot{token}/editMessageMedia",
                 data=data, files={'media_file': f}, timeout=60
             )
             if resp.ok:
-                log.info(f"{tag} Replaced photo with video")
+                log_telegram_event(
+                    logging.INFO,
+                    tag,
+                    "Replaced photo with video",
+                    "telegram_media_replaced",
+                    config,
+                    service_logger=service_logger,
+                    text=caption,
+                    caption_source="video",
+                    message_id=config['last_msg_id'],
+                )
                 return True
             else:
-                log.error(f"{tag} Replace media error: {resp.text}")
-    except Exception as e:
-        log.error(f"{tag} Replace media error: {e}")
+                log_telegram_event(
+                    logging.ERROR,
+                    tag,
+                    "Telegram media replace failed",
+                    "telegram_media_replace_failed",
+                    config,
+                    service_logger=service_logger,
+                    error_code="telegram_media_replace_failed",
+                    text=caption,
+                    caption_source="video",
+                    message_id=config['last_msg_id'],
+                )
+    except Exception:
+        log_telegram_event(
+            logging.ERROR,
+            tag,
+            "Telegram media replace error",
+            "telegram_media_replace_failed",
+            config,
+            service_logger=service_logger,
+            error_code="telegram_media_replace_failed",
+            text=caption,
+            caption_source="video",
+            message_id=config['last_msg_id'],
+        )
     return False
 
 
@@ -883,14 +1062,35 @@ def process_alert(image_path, config):
         if instant_notify:
             send_telegram(config, image_path, "Motion detected.")
             if ai_text:
-                update_telegram_caption(config, still_caption)
+                update_telegram_caption(
+                    config,
+                    still_caption,
+                    caption_source="still",
+                    previous_text="Motion detected.",
+                )
         else:
             send_telegram(config, image_path, still_caption)
 
         # DVLA enrichment after Telegram send — edits the caption if plates are found (#66)
         enriched_still = enrich_caption_with_dvla(still_caption, config, tag, image_path=image_path)
+        log_telegram_event(
+            logging.INFO,
+            tag,
+            "DVLA still-caption enrichment complete",
+            "dvla_caption_enriched",
+            config,
+            text=enriched_still,
+            caption_source="dvla",
+            caption_changed=(enriched_still != still_caption),
+            message_id=config.get("last_msg_id"),
+        )
         if enriched_still != still_caption:
-            update_telegram_caption(config, enriched_still)
+            update_telegram_caption(
+                config,
+                enriched_still,
+                caption_source="dvla",
+                previous_text=still_caption,
+            )
         still_caption = enriched_still
 
         # Video handling

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -24,6 +24,7 @@ from tasks import (
     analyze_video_gemini,
     deliver_video_to_telegram,
     enrich_caption_with_dvla,
+    log_telegram_event,
     update_telegram_caption,
 )
 
@@ -145,10 +146,36 @@ def _process_delivery_request(request_id):
 
     video_caption = analyze_video_gemini(config, raw_mp4, delivery.get("prompt", "Describe the clip."))
     if video_caption:
+        log_telegram_event(
+            logging.INFO,
+            tag,
+            "Video caption generated",
+            "video_caption_generated",
+            config,
+            service_logger=logger,
+            text=video_caption,
+            caption_source="video",
+            message_id=config.get("last_msg_id"),
+        )
+        enriched_caption = enrich_caption_with_dvla(video_caption, config, tag)
+        log_telegram_event(
+            logging.INFO,
+            tag,
+            "DVLA video-caption enrichment complete",
+            "dvla_caption_enriched",
+            config,
+            service_logger=logger,
+            text=enriched_caption,
+            caption_source="dvla",
+            caption_changed=(enriched_caption != video_caption),
+            message_id=config.get("last_msg_id"),
+        )
         update_telegram_caption(
             config,
-            enrich_caption_with_dvla(video_caption, config, tag),
+            enriched_caption,
             service_logger=logger,
+            caption_source="video",
+            previous_text=delivery.get("still_caption"),
         )
 
     _cleanup_paths(optimised_mp4, raw_mp4)

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1,6 +1,7 @@
 import os
 import uuid
 import json
+import re
 import sqlite3
 import redis
 import logging
@@ -176,9 +177,32 @@ init_db()
 
 # --- HELPERS ---
 
-def get_log_content():
+_LOG_TAG_RE = re.compile(r'(\[[^\]]+\]\[[^\]]+\])')
+
+
+def _parse_log_line(source_name, line):
+    line = line.rstrip("\n")
+    if not line:
+        return None
+
+    timestamp = line[:23] if len(line) >= 23 else ""
+    message = line[33:] if " - " in line else line
+    tag_match = _LOG_TAG_RE.search(message)
+    alert_tag = tag_match.group(1) if tag_match else None
+
+    return {
+        "source": source_name,
+        "timestamp": timestamp,
+        "line": line,
+        "display": f"[{source_name}] {line}",
+        "alert_tag": alert_tag,
+        "is_trigger": source_name == "system.log" and "Webhook triggered." in message,
+    }
+
+
+def get_log_entries():
     if not os.path.isdir(LOG_DIR):
-        return "No logs yet."
+        return []
 
     try:
         entries = []
@@ -187,24 +211,30 @@ def get_log_content():
             if name.endswith(".log") and os.path.isfile(os.path.join(LOG_DIR, name))
         )
         if not log_files:
-            return "No logs yet."
+            return []
 
         for name in log_files:
             path = os.path.join(LOG_DIR, name)
             with open(path) as f:
                 for line in f.readlines()[-200:]:
-                    line = line.rstrip("\n")
-                    if not line:
-                        continue
-                    entries.append((line[:23], f"[{name}] {line}"))
+                    parsed = _parse_log_line(name, line)
+                    if parsed:
+                        entries.append(parsed)
 
         if not entries:
-            return "No logs yet."
+            return []
 
-        entries.sort(key=lambda item: item[0])
-        return "\n".join(line for _, line in entries[-200:])
+        entries.sort(key=lambda item: item["timestamp"])
+        return entries[-200:]
     except Exception as e:
-        return f"Error reading logs: {e}"
+        return [{
+            "source": "system",
+            "timestamp": "",
+            "line": f"Error reading logs: {e}",
+            "display": f"[system] Error reading logs: {e}",
+            "alert_tag": None,
+            "is_trigger": False,
+        }]
 
 
 def load_known_plates():
@@ -293,6 +323,9 @@ HTML_TEMPLATE = r"""
         .nav-tabs .nav-link.active { font-weight: bold; }
         .status-badge { font-size: 0.8em; }
         .last-seen { font-size: 0.85em; color: var(--bs-secondary-color); }
+        .log-group { border: 1px solid var(--bs-border-color); border-radius: 6px; margin-bottom: 8px; padding: 6px 8px; }
+        .log-group summary { cursor: pointer; font-weight: 500; }
+        .log-group-body { margin-top: 8px; padding-left: 12px; border-left: 2px solid var(--bs-border-color); }
         body, .card, .webhook-box, .modal-content { transition: background-color 0.3s, color 0.3s; }
         .mute-badge { font-size: 0.75em; }
         .modal-footer .btn { border-radius: 6px; padding: 8px 20px; font-weight: 500; }
@@ -482,7 +515,7 @@ HTML_TEMPLATE = r"""
                     </form>
                 </div>
             </div>
-            <div class="log-viewer" id="logViewer">{{ logs }}</div>
+            <div class="log-viewer" id="logViewer" data-log-entries='{{ log_entries|tojson|safe }}'></div>
         </div>
 
         <!-- Plate Audit tab -->
@@ -667,31 +700,78 @@ const colors = [
     '#afeeee', '#ee82ee', '#98fb98'
 ];
 function stringToColor(s){let h=0;for(let i=0;i<s.length;i++){h=s.charCodeAt(i)+((h<<5)-h);}return colors[Math.abs(h)%colors.length];}
-function escapeHtml(s){return s.replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');}
-function logSource(line){const match=line.match(/^\[([^\]]+)\]/);return match?match[1]:'unknown';}
-function populateLogSourceFilter(lines){
+function escapeHtml(s){return String(s).replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;');}
+function logSource(entry){return entry&&entry.source?entry.source:'unknown';}
+function logTag(entry){return entry&&entry.alert_tag?entry.alert_tag:'';}
+function colorKey(entry){
+    const tag=logTag(entry);
+    if(tag)return tag;
+    return entry&&entry.source?entry.source:'';
+}
+function populateLogSourceFilter(entries){
     const select=document.getElementById('logSourceFilter');
     if(!select)return;
     const current=select.value||'all';
-    const sources=[...new Set(lines.map(logSource).filter(Boolean))].sort();
+    const sources=[...new Set(entries.map(logSource).filter(Boolean))].sort();
     select.innerHTML='<option value="all">All sources</option>'+sources.map(s=>`<option value="${s}">${s}</option>`).join('');
     select.value=sources.includes(current)||current==='all'?current:'all';
+}
+function renderLogLine(entry){
+    const key=colorKey(entry);
+    return `<div data-source="${escapeHtml(entry.source)}" style="color:${key?stringToColor(key):'#888'}">${escapeHtml(entry.display)}</div>`;
+}
+function buildGroupedLogs(entries){
+    const triggerTags=new Set(entries.filter(e=>e.is_trigger&&e.alert_tag).map(e=>e.alert_tag));
+    const grouped=new Map();
+    const ungrouped=[];
+
+    entries.forEach(entry=>{
+        if(entry.alert_tag && triggerTags.has(entry.alert_tag)){
+            if(!grouped.has(entry.alert_tag))grouped.set(entry.alert_tag, []);
+            grouped.get(entry.alert_tag).push(entry);
+        }else{
+            ungrouped.push(entry);
+        }
+    });
+
+    const blocks=[];
+    const seenGroups=new Set();
+    entries.forEach(entry=>{
+        if(entry.alert_tag && triggerTags.has(entry.alert_tag)){
+            if(seenGroups.has(entry.alert_tag))return;
+            seenGroups.add(entry.alert_tag);
+            const group=grouped.get(entry.alert_tag)||[];
+            const trigger=group.find(e=>e.is_trigger)||group[0];
+            const body=group.map(renderLogLine).join('');
+            blocks.push(
+                `<details class="log-group"><summary style="color:${stringToColor(colorKey(trigger))}">${escapeHtml(trigger.display)}</summary><div class="log-group-body">${body}</div></details>`
+            );
+        }else{
+            blocks.push(renderLogLine(entry));
+        }
+    });
+    return blocks.join('');
 }
 function renderLogs(){
     const v=document.getElementById('logViewer');
     if(!v)return;
-    if(!v.dataset.rawLogs){v.dataset.rawLogs=v.innerText;}
-    const lines=v.dataset.rawLogs.split('\n').filter(l=>l.trim());
-    populateLogSourceFilter(lines);
+    let entries=[];
+    try{
+        entries=JSON.parse(v.dataset.logEntries||'[]');
+    }catch(_e){
+        entries=[];
+    }
+    populateLogSourceFilter(entries);
     const selected=(document.getElementById('logSourceFilter')||{}).value||'all';
+    const filtered=selected==='all'?entries:entries.filter(e=>e.source===selected);
     let html='';
-    lines.forEach(l=>{
-        const source=logSource(l);
-        if(selected!=='all'&&source!==selected)return;
-        const matches=[...l.matchAll(/\[([^\]]+)\]/g)];
-        const key=matches.length?matches[matches.length-1][1]:'';
-        html+=`<div data-source="${source}" style="color:${key?stringToColor(key):'#888'}">${escapeHtml(l)}</div>`;
-    });
+    if(!filtered.length){
+        html='<div class="text-muted">No logs yet.</div>';
+    }else if(selected==='all'){
+        html=buildGroupedLogs(filtered);
+    }else{
+        html=filtered.map(renderLogLine).join('');
+    }
     v.innerHTML=html;
     v.scrollTop=v.scrollHeight;
 }
@@ -769,7 +849,7 @@ def index():
         HTML_TEMPLATE,
         configs=configs,
         plate_audit=plate_audit,
-        logs=get_log_content(),
+        log_entries=get_log_entries(),
         base_url=BASE_URL,
         mutes=mutes,
         caption_mode=caption_mode,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,69 @@
+import logging
+
+import tasks
+
+
+class _DummyResponse:
+    def __init__(self, ok=True, status_code=200, payload=None):
+        self.ok = ok
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_send_telegram_logs_photo_sent(tmp_path, monkeypatch, caplog):
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+    }
+
+    monkeypatch.setattr(
+        tasks.requests,
+        "post",
+        lambda *args, **kwargs: _DummyResponse(
+            ok=True,
+            payload={"result": {"message_id": 321}},
+        ),
+    )
+
+    with caplog.at_level(logging.INFO):
+        tasks.send_telegram(config, str(image_path), "Motion detected.")
+
+    assert config["last_msg_id"] == 321
+    assert "phase=telegram_photo_sent" in caplog.text
+    assert "caption_source=still" in caplog.text
+    assert "message_id=321" in caplog.text
+
+
+def test_update_telegram_caption_logs_source_and_change(monkeypatch, caplog):
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+        "last_msg_id": 654,
+    }
+
+    monkeypatch.setattr(tasks.requests, "post", lambda *args, **kwargs: _DummyResponse(ok=True))
+
+    with caplog.at_level(logging.INFO):
+        ok = tasks.update_telegram_caption(
+            config,
+            "Vehicle AB12 CDE arrived",
+            caption_source="dvla",
+            previous_text="Vehicle arrived",
+        )
+
+    assert ok is True
+    assert "phase=telegram_caption_update_started" in caplog.text
+    assert "phase=telegram_caption_updated" in caplog.text
+    assert "caption_source=dvla" in caplog.text
+    assert "caption_changed=true" in caplog.text
+    assert "message_id=654" in caplog.text

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,12 +1,54 @@
+import wsgi
+
+
 def test_dashboard_loads(client):
     """Test that the main dashboard loads successfully."""
     response = client.get('/')
     assert response.status_code == 200
     assert b"Blue Iris AI Hub" in response.data
 
-def test_api_check_update(client):
+def test_api_check_update(client, monkeypatch):
     """Test that the update API endpoint returns JSON."""
+    monkeypatch.setattr(wsgi.r, "get", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(wsgi.r, "set", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        wsgi,
+        "get_update_status",
+        lambda: {"update_available": False, "latest_version": None, "current_version": "test"},
+    )
     response = client.get('/api/check-update')
     assert response.status_code == 200
     data = response.get_json()
     assert "update_available" in data
+
+
+def test_get_log_entries_marks_webhook_trigger_and_alert_tag(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    log_file = log_dir / "system.log"
+    log_file.write_text(
+        "\n".join(
+            [
+                (
+                    "2026-04-12 12:42:08,592 - INFO - [Driveway][0382523c] "
+                    "Webhook triggered. File: "
+                    "Driveway.20260412_130000.2517804.3-1.jpg"
+                ),
+                (
+                    "2026-04-12 12:42:08,700 - INFO - [Driveway][0382523c] "
+                    "Processing alert... | phase=alert_processing_started"
+                ),
+            ]
+        )
+    )
+
+    monkeypatch.setattr(wsgi, "LOG_DIR", str(log_dir))
+
+    entries = wsgi.get_log_entries()
+
+    assert len(entries) == 2
+    assert entries[0]["source"] == "system.log"
+    assert entries[0]["alert_tag"] == "[Driveway][0382523c]"
+    assert entries[0]["is_trigger"] is True
+    assert entries[1]["alert_tag"] == "[Driveway][0382523c]"
+    assert entries[1]["is_trigger"] is False


### PR DESCRIPTION
 Fixes #102

  Adds structured logging around Telegram photo sends, caption updates, media replacement, DVLA caption enrichment, and video-caption generation so logs show whether Telegram message/caption operations were attempted, changed, and accepted.
