### PR TITLE
Fix DVLA logging semantics and async video caption key handling

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1073,17 +1073,18 @@ def process_alert(image_path, config):
 
         # DVLA enrichment after Telegram send — edits the caption if plates are found (#66)
         enriched_still = enrich_caption_with_dvla(still_caption, config, tag, image_path=image_path)
-        log_telegram_event(
-            logging.INFO,
-            tag,
-            "DVLA still-caption enrichment complete",
-            "dvla_caption_enriched",
-            config,
-            text=enriched_still,
-            caption_source="dvla",
-            caption_changed=(enriched_still != still_caption),
-            message_id=config.get("last_msg_id"),
-        )
+        if (config.get("dvla_api_key") or "").strip():
+            log_telegram_event(
+                logging.INFO,
+                tag,
+                "DVLA still-caption enrichment complete",
+                "dvla_caption_enriched",
+                config,
+                text=enriched_still,
+                caption_source="dvla",
+                caption_changed=(enriched_still != still_caption),
+                message_id=config.get("last_msg_id"),
+            )
         if enriched_still != still_caption:
             update_telegram_caption(
                 config,
@@ -1107,9 +1108,8 @@ def process_alert(image_path, config):
                         "message_thread_id": config.get("message_thread_id"),
                         "last_msg_id": config.get("last_msg_id"),
                         "dvla_api_key": config.get("dvla_api_key", ""),
-                        "gemini_api_key1": config.get("gemini_api_key1", ""),
-                        "gemini_api_key2": config.get("gemini_api_key2", ""),
-                        "gemini_api_key3": config.get("gemini_api_key3", ""),
+                        "gemini_key": config.get("gemini_key", ""),
+                        "verbose_logging": config.get("verbose_logging", 0),
                     },
                     "prompt": prompt,
                     "still_caption": still_caption,

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -177,6 +177,21 @@ def _process_delivery_request(request_id):
             caption_source="video",
             previous_text=delivery.get("still_caption"),
         )
+    else:
+        error_code = "video_caption_unavailable"
+        if not (config.get("gemini_key") or "").strip():
+            error_code = "missing_gemini_key"
+        log_telegram_event(
+            logging.WARNING,
+            tag,
+            "Video caption unavailable; keeping still caption",
+            "video_caption_unavailable",
+            config,
+            service_logger=logger,
+            error_code=error_code,
+            caption_source="video",
+            message_id=config.get("last_msg_id"),
+        )
 
     _cleanup_paths(optimised_mp4, raw_mp4)
     finish_delivery(load_job(request_id) or job, True, None)

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -431,9 +431,7 @@ class TestVideoDeliveryWorker:
                     "chat_id": "chat",
                     "last_msg_id": 42,
                     "dvla_api_key": "",
-                    "gemini_api_key1": "",
-                    "gemini_api_key2": "",
-                    "gemini_api_key3": "",
+                    "gemini_key": "gemini-key",
                 },
                 "prompt": "describe this",
                 "still_caption": "Motion detected.",
@@ -457,3 +455,67 @@ class TestVideoDeliveryWorker:
         assert stored["status"] == "completed"
         assert stored["delivery_status"] == "completed"
         assert not os.path.exists(raw_mp4)
+
+    def test_video_delivery_logs_missing_gemini_key_when_caption_unavailable(self, monkeypatch):
+        raw_mp4 = "/tmp/video_delivery_worker_missing_key_raw.mp4"
+        with open(raw_mp4, "wb") as fh:
+            fh.write(b"video-data")
+
+        payload = _request_payload(output_path=raw_mp4)
+        job = {
+            "request_id": payload["request_id"],
+            "config_name": payload["config_name"],
+            "request": payload,
+            "bi_url": payload["bi_url"],
+            "bi_user": payload["bi_user"],
+            "bi_pass": payload["bi_pass"],
+            "output_path": raw_mp4,
+            "target_path": "@queued",
+            "relative_uri": "Clipboard/foo.mp4",
+            "delete_after": False,
+            "restart_url": "",
+            "restart_token": "",
+            "status": "downloaded",
+            "delivery_context": {
+                "config": {
+                    "id": 1,
+                    "name": "TestCam",
+                    "request_id": "req",
+                    "telegram_token": "token",
+                    "chat_id": "chat",
+                    "last_msg_id": 42,
+                    "dvla_api_key": "",
+                    "gemini_key": "",
+                },
+                "prompt": "describe this",
+                "still_caption": "Motion detected.",
+            },
+            "delivery_status": "queued",
+            "delivery_attempts": 0,
+        }
+        bi_export_shared.save_job(job)
+        monkeypatch.setattr(
+            video_delivery_worker,
+            "deliver_video_to_telegram",
+            lambda *args, **kwargs: (raw_mp4.replace("_raw.mp4", ".mp4"), True),
+        )
+        monkeypatch.setattr(video_delivery_worker, "analyze_video_gemini", lambda *args, **kwargs: None)
+        logged = []
+        monkeypatch.setattr(
+            video_delivery_worker,
+            "log_telegram_event",
+            lambda level, tag, message, phase, config, **kwargs: logged.append(
+                {
+                    "level": level,
+                    "tag": tag,
+                    "message": message,
+                    "phase": phase,
+                    "kwargs": kwargs,
+                }
+            ),
+        )
+
+        video_delivery_worker._process_delivery_request(job["request_id"])
+
+        assert any(item["phase"] == "video_caption_unavailable" for item in logged)
+        assert any(item["kwargs"].get("error_code") == "missing_gemini_key" for item in logged)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -67,3 +67,35 @@ def test_update_telegram_caption_logs_source_and_change(monkeypatch, caplog):
     assert "caption_source=dvla" in caplog.text
     assert "caption_changed=true" in caplog.text
     assert "message_id=654" in caplog.text
+
+
+def test_process_alert_does_not_log_dvla_enrichment_without_key(tmp_path, monkeypatch, caplog):
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "id": "cfg1",
+        "name": "Front",
+        "request_id": "req12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+        "prompt": "Describe motion.",
+        "instant_notify": 0,
+        "send_video": 0,
+        "trigger_filename": "",
+        "dvla_api_key": "",
+        "verbose_logging": 0,
+    }
+
+    monkeypatch.setattr(tasks, "is_muted", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(tasks, "check_auto_mute", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(tasks, "build_prompt", lambda *_args, **_kwargs: "Describe motion.")
+    monkeypatch.setattr(tasks, "optimize_image", lambda *_args, **_kwargs: "encoded")
+    monkeypatch.setattr(tasks, "analyze_image_parallel", lambda *_args, **_kwargs: "Vehicle arrived")
+    monkeypatch.setattr(tasks, "send_telegram", lambda cfg, *_args, **_kwargs: cfg.update({"last_msg_id": 321}))
+    monkeypatch.setattr(tasks, "enrich_caption_with_dvla", lambda text, *_args, **_kwargs: text)
+
+    with caplog.at_level(logging.INFO):
+        tasks.process_alert(str(image_path), config)
+
+    assert "phase=dvla_caption_enriched" not in caplog.text


### PR DESCRIPTION
Fixes the misleading `dvla_caption_enriched` log when no DVLA API key is configured, passes the correct `gemini_key` into async video delivery so video captions can be generated, and adds explicit `video_caption_unavailable` logging when the still caption is kept.