### PR TITLE
Fix DVLA video-caption skip logging semantics

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -80,11 +80,13 @@ def log_telegram_event(
     caption_source=None,
     caption_changed=None,
     message_id=None,
+    reason=None,
 ):
     log = _resolve_logger(service_logger)
     suffix = _format_log_fields(
         phase=phase,
         error_code=error_code,
+        reason=reason,
         **_telegram_log_fields(
             config,
             text=text,

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -157,19 +157,35 @@ def _process_delivery_request(request_id):
             caption_source="video",
             message_id=config.get("last_msg_id"),
         )
-        enriched_caption = enrich_caption_with_dvla(video_caption, config, tag)
-        log_telegram_event(
-            logging.INFO,
-            tag,
-            "DVLA video-caption enrichment complete",
-            "dvla_caption_enriched",
-            config,
-            service_logger=logger,
-            text=enriched_caption,
-            caption_source="dvla",
-            caption_changed=(enriched_caption != video_caption),
-            message_id=config.get("last_msg_id"),
-        )
+        dvla_key = (config.get("dvla_api_key") or "").strip()
+        if dvla_key:
+            enriched_caption = enrich_caption_with_dvla(video_caption, config, tag)
+            log_telegram_event(
+                logging.INFO,
+                tag,
+                "DVLA video-caption enrichment complete",
+                "dvla_caption_enriched",
+                config,
+                service_logger=logger,
+                text=enriched_caption,
+                caption_source="dvla",
+                caption_changed=(enriched_caption != video_caption),
+                message_id=config.get("last_msg_id"),
+            )
+        else:
+            enriched_caption = video_caption
+            log_telegram_event(
+                logging.INFO,
+                tag,
+                "DVLA video-caption enrichment skipped",
+                "dvla_caption_skipped",
+                config,
+                service_logger=logger,
+                caption_source="dvla",
+                caption_changed=False,
+                message_id=config.get("last_msg_id"),
+                reason="no_api_key",
+            )
         update_telegram_caption(
             config,
             enriched_caption,

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -519,3 +519,69 @@ class TestVideoDeliveryWorker:
 
         assert any(item["phase"] == "video_caption_unavailable" for item in logged)
         assert any(item["kwargs"].get("error_code") == "missing_gemini_key" for item in logged)
+
+    def test_video_delivery_logs_dvla_skip_when_no_key_configured(self, monkeypatch):
+        raw_mp4 = "/tmp/video_delivery_worker_dvla_skip_raw.mp4"
+        with open(raw_mp4, "wb") as fh:
+            fh.write(b"video-data")
+
+        payload = _request_payload(output_path=raw_mp4)
+        job = {
+            "request_id": payload["request_id"],
+            "config_name": payload["config_name"],
+            "request": payload,
+            "bi_url": payload["bi_url"],
+            "bi_user": payload["bi_user"],
+            "bi_pass": payload["bi_pass"],
+            "output_path": raw_mp4,
+            "target_path": "@queued",
+            "relative_uri": "Clipboard/foo.mp4",
+            "delete_after": False,
+            "restart_url": "",
+            "restart_token": "",
+            "status": "downloaded",
+            "delivery_context": {
+                "config": {
+                    "id": 1,
+                    "name": "TestCam",
+                    "request_id": "req",
+                    "telegram_token": "token",
+                    "chat_id": "chat",
+                    "last_msg_id": 42,
+                    "dvla_api_key": "",
+                    "gemini_key": "gemini-key",
+                },
+                "prompt": "describe this",
+                "still_caption": "Motion detected.",
+            },
+            "delivery_status": "queued",
+            "delivery_attempts": 0,
+        }
+        bi_export_shared.save_job(job)
+        monkeypatch.setattr(
+            video_delivery_worker,
+            "deliver_video_to_telegram",
+            lambda *args, **kwargs: (raw_mp4.replace("_raw.mp4", ".mp4"), True),
+        )
+        monkeypatch.setattr(video_delivery_worker, "analyze_video_gemini", lambda *args, **kwargs: "Car on drive")
+        monkeypatch.setattr(video_delivery_worker, "update_telegram_caption", lambda *args, **kwargs: True)
+        logged = []
+        monkeypatch.setattr(
+            video_delivery_worker,
+            "log_telegram_event",
+            lambda level, tag, message, phase, config, **kwargs: logged.append(
+                {
+                    "level": level,
+                    "tag": tag,
+                    "message": message,
+                    "phase": phase,
+                    "kwargs": kwargs,
+                }
+            ),
+        )
+
+        video_delivery_worker._process_delivery_request(job["request_id"])
+
+        assert any(item["phase"] == "dvla_caption_skipped" for item in logged)
+        assert any(item["kwargs"].get("reason") == "no_api_key" for item in logged)
+        assert not any(item["phase"] == "dvla_caption_enriched" for item in logged)


### PR DESCRIPTION
Fixes the video-caption DVLA log semantics so cameras without a DVLA API key log `phase=dvla_caption_skipped reason=no_api_key` instead of the misleading `dvla_caption_enriched`, while keeping `dvla_caption_enriched` for real DVLA enrichment runs.