### PR TITLE
fix: fall back to sendAnimation when initial still photo send failed

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -661,7 +661,7 @@ def send_telegram(config, img_path, caption, service_logger=None):
 
 
 def update_telegram_caption(config, text, service_logger=None, caption_source="unknown", previous_text=None):
-    if 'last_msg_id' not in config:
+    if not config.get('last_msg_id'):
         req_id = config.get('request_id', 'unknown')
         tag = f"[{config['name']}][{req_id}]"
         log_telegram_event(
@@ -745,13 +745,76 @@ def update_telegram_caption(config, text, service_logger=None, caption_source="u
 def replace_telegram_media(config, media_path, caption, service_logger=None):
     req_id = config.get('request_id', 'unknown')
     tag = f"[{config['name']}][{req_id}]"
-
-    if 'last_msg_id' not in config:
-        return False
     token = config['telegram_token']
     chat_id = config['chat_id']
+    thread_id = _tg_thread(config)
+    last_msg_id = config.get('last_msg_id')
+
+    if not last_msg_id:
+        # The initial still photo send failed — no message to edit.
+        # Fall back to sending the video as a new message.
+        log_telegram_event(
+            logging.WARNING,
+            tag,
+            "No still message to replace; sending video as new message",
+            "telegram_video_fallback_send",
+            config,
+            service_logger=service_logger,
+            text=caption,
+            caption_source="video",
+        )
+        data = {'chat_id': chat_id, 'caption': caption}
+        if thread_id:
+            data['message_thread_id'] = thread_id
+        try:
+            with open(media_path, 'rb') as f:
+                resp = requests.post(
+                    f"https://api.telegram.org/bot{token}/sendAnimation",
+                    data=data, files={'animation': f}, timeout=60
+                )
+                if resp.ok:
+                    config['last_msg_id'] = resp.json()['result']['message_id']
+                    log_telegram_event(
+                        logging.INFO,
+                        tag,
+                        "Video sent as new message",
+                        "telegram_video_sent",
+                        config,
+                        service_logger=service_logger,
+                        text=caption,
+                        caption_source="video",
+                        message_id=config['last_msg_id'],
+                    )
+                    return True
+                else:
+                    log_telegram_event(
+                        logging.ERROR,
+                        tag,
+                        "Telegram video fallback send failed",
+                        "telegram_video_fallback_failed",
+                        config,
+                        service_logger=service_logger,
+                        error_code="telegram_video_fallback_failed",
+                        text=caption,
+                        caption_source="video",
+                    )
+        except Exception:
+            log_telegram_event(
+                logging.ERROR,
+                tag,
+                "Telegram video fallback send error",
+                "telegram_video_fallback_failed",
+                config,
+                service_logger=service_logger,
+                error_code="telegram_video_fallback_failed",
+                text=caption,
+                caption_source="video",
+            )
+        return False
+
+    # Normal path: edit the existing still photo message.
     media_json = json.dumps({"type": "animation", "media": "attach://media_file", "caption": caption})
-    data = {'chat_id': chat_id, 'message_id': config['last_msg_id'], 'media': media_json}
+    data = {'chat_id': chat_id, 'message_id': last_msg_id, 'media': media_json}
     try:
         log_telegram_event(
             logging.INFO,
@@ -762,7 +825,7 @@ def replace_telegram_media(config, media_path, caption, service_logger=None):
             service_logger=service_logger,
             text=caption,
             caption_source="video",
-            message_id=config['last_msg_id'],
+            message_id=last_msg_id,
         )
         with open(media_path, 'rb') as f:
             resp = requests.post(
@@ -779,7 +842,7 @@ def replace_telegram_media(config, media_path, caption, service_logger=None):
                     service_logger=service_logger,
                     text=caption,
                     caption_source="video",
-                    message_id=config['last_msg_id'],
+                    message_id=last_msg_id,
                 )
                 return True
             else:
@@ -793,7 +856,7 @@ def replace_telegram_media(config, media_path, caption, service_logger=None):
                     error_code="telegram_media_replace_failed",
                     text=caption,
                     caption_source="video",
-                    message_id=config['last_msg_id'],
+                    message_id=last_msg_id,
                 )
     except Exception:
         log_telegram_event(
@@ -806,7 +869,7 @@ def replace_telegram_media(config, media_path, caption, service_logger=None):
             error_code="telegram_media_replace_failed",
             text=caption,
             caption_source="video",
-            message_id=config['last_msg_id'],
+            message_id=last_msg_id,
         )
     return False
 

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -58,7 +58,7 @@ def _process_delivery_request(request_id):
 
     delivery = job.get("delivery_context") or {}
     config = delivery.get("config") or {}
-    if not config or "last_msg_id" not in config:
+    if not config or not config.get("telegram_token") or not config.get("chat_id"):
         log_terminal_diagnosis(
             logger,
             job_tag(job),
@@ -127,6 +127,10 @@ def _process_delivery_request(request_id):
             delivery.get("prompt", "Describe the clip."),
         )
         media_ok = media_future.result()
+
+    # Persist config.last_msg_id back onto the job so that a crash/restart
+    # after a successful fallback sendAnimation doesn't trigger a duplicate send.
+    save_job(job)
 
     if not media_ok:
         if job["delivery_attempts"] < MAX_DELIVERY_ATTEMPTS:

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -636,3 +636,61 @@ class TestVideoDeliveryWorker:
         video_delivery_worker._process_delivery_request(job["request_id"])
 
         assert analysis_started.is_set()
+
+    def test_fallback_send_persists_new_msg_id_to_redis(self, monkeypatch):
+        """Crash/retry path: after a successful fallback sendAnimation, the new
+        last_msg_id must be flushed to Redis so a restarted worker doesn't
+        call sendAnimation again and create a duplicate Telegram message."""
+        raw_mp4 = "/tmp/video_delivery_worker_fallback_raw.mp4"
+        with open(raw_mp4, "wb") as fh:
+            fh.write(b"video-data")
+
+        payload = _request_payload(output_path=raw_mp4)
+        job = {
+            "request_id": payload["request_id"],
+            "config_name": payload["config_name"],
+            "request": payload,
+            "bi_url": payload["bi_url"],
+            "bi_user": payload["bi_user"],
+            "bi_pass": payload["bi_pass"],
+            "output_path": raw_mp4,
+            "target_path": "@queued",
+            "relative_uri": "Clipboard/foo.mp4",
+            "delete_after": False,
+            "restart_url": "",
+            "restart_token": "",
+            "status": "downloaded",
+            "delivery_context": {
+                "config": {
+                    "id": 1,
+                    "name": "TestCam",
+                    "request_id": "req",
+                    "telegram_token": "token",
+                    "chat_id": "chat",
+                    "last_msg_id": None,
+                    "dvla_api_key": "",
+                    "gemini_key": "",
+                },
+                "prompt": "describe this",
+                "still_caption": "Motion detected.",
+            },
+            "delivery_status": "queued",
+            "delivery_attempts": 0,
+        }
+        bi_export_shared.save_job(job)
+
+        def fake_replace(config, *_args, **_kwargs):
+            # Simulate the fallback sendAnimation setting a new message id.
+            config["last_msg_id"] = 888
+            return True
+
+        monkeypatch.setattr(video_delivery_worker, "optimize_video_for_telegram", lambda *args, **kwargs: True)
+        monkeypatch.setattr(video_delivery_worker, "replace_telegram_media", fake_replace)
+        monkeypatch.setattr(video_delivery_worker, "analyze_video_gemini", lambda *args, **kwargs: None)
+        monkeypatch.setattr(video_delivery_worker, "enrich_caption_with_dvla", lambda text, *_args, **_kwargs: text)
+        monkeypatch.setattr(video_delivery_worker, "update_telegram_caption", lambda *args, **kwargs: True)
+
+        video_delivery_worker._process_delivery_request(job["request_id"])
+
+        stored = bi_export_shared.load_job(job["request_id"])
+        assert stored["delivery_context"]["config"]["last_msg_id"] == 888

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -201,3 +201,111 @@ def test_enrich_caption_without_plate_returns_original_text(monkeypatch):
     )
 
     assert caption == "Vehicle arrived on driveway"
+
+
+# ---------------------------------------------------------------------------
+# replace_telegram_media — fallback to sendAnimation when last_msg_id is None
+# ---------------------------------------------------------------------------
+
+def _make_video_config(**overrides):
+    cfg = {
+        "name": "Driveway",
+        "request_id": "de12f077",
+        "telegram_token": "token",
+        "chat_id": "123",
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def test_replace_telegram_media_falls_back_to_send_when_no_msg_id(tmp_path, monkeypatch):
+    """When last_msg_id is None, sendAnimation is called instead of editMessageMedia."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-video")
+
+    captured = {}
+
+    def fake_post(url, data=None, files=None, timeout=None):
+        captured["url"] = url
+        captured["files"] = list(files.keys()) if files else []
+        return _DummyResponse(ok=True, payload={"result": {"message_id": 999}})
+
+    config = _make_video_config(last_msg_id=None)
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+
+    result = tasks.replace_telegram_media(config, str(video), "Motion detected.")
+
+    assert result is True
+    assert "sendAnimation" in captured["url"]
+    assert "editMessageMedia" not in captured["url"]
+    assert "animation" in captured["files"]
+    assert config["last_msg_id"] == 999
+
+
+def test_replace_telegram_media_falls_back_when_key_missing(tmp_path, monkeypatch):
+    """When last_msg_id key is absent entirely, sendAnimation is called."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-video")
+
+    captured = {}
+
+    def fake_post(url, data=None, files=None, timeout=None):
+        captured["url"] = url
+        return _DummyResponse(ok=True, payload={"result": {"message_id": 42}})
+
+    config = _make_video_config()  # no last_msg_id key at all
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+
+    result = tasks.replace_telegram_media(config, str(video), "Motion detected.")
+
+    assert result is True
+    assert "sendAnimation" in captured["url"]
+    assert config["last_msg_id"] == 42
+
+
+def test_replace_telegram_media_uses_edit_when_msg_id_present(tmp_path, monkeypatch):
+    """Normal path: last_msg_id present → editMessageMedia, no sendAnimation."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-video")
+
+    captured = {}
+
+    def fake_post(url, data=None, files=None, timeout=None):
+        captured["url"] = url
+        return _DummyResponse(ok=True, payload={})
+
+    config = _make_video_config(last_msg_id=555)
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+
+    result = tasks.replace_telegram_media(config, str(video), "Motion detected.")
+
+    assert result is True
+    assert "editMessageMedia" in captured["url"]
+    assert "sendAnimation" not in captured["url"]
+
+
+def test_replace_telegram_media_fallback_sets_last_msg_id_for_caption_update(tmp_path, monkeypatch):
+    """After fallback send, last_msg_id is updated so caption updates work."""
+    video = tmp_path / "clip.mp4"
+    video.write_bytes(b"fake-video")
+
+    calls = []
+
+    def fake_post(url, data=None, files=None, timeout=None):
+        calls.append(url)
+        if "sendAnimation" in url:
+            return _DummyResponse(ok=True, payload={"result": {"message_id": 777}})
+        if "editMessageCaption" in url:
+            assert data.get("message_id") == 777
+            return _DummyResponse(ok=True, payload={})
+        return _DummyResponse(ok=False)
+
+    config = _make_video_config(last_msg_id=None)
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+
+    tasks.replace_telegram_media(config, str(video), "Motion detected.")
+    tasks.update_telegram_caption(config, "Car in driveway.")
+
+    assert any("sendAnimation" in c for c in calls)
+    assert any("editMessageCaption" in c for c in calls)
+


### PR DESCRIPTION
## Problem

When the initial Telegram still photo send fails (e.g. `ConnectionResetError(104, 'Connection reset by peer')`), `last_msg_id` is never set on `config`. `process_alert` snapshots `None` into the delivery context and queues the video job normally.

Two minutes later `video_delivery_worker` calls `replace_telegram_media` with `last_msg_id=None`. The old guard was:

```python
if 'last_msg_id' not in config:   # False — key IS present, value is None
    return False
```

So `editMessageMedia` was called with `message_id=None`, Telegram returned `400 Bad Request: message to edit not found` on all three delivery attempts, and the video was silently abandoned.

Observed in logs:
```
21:19:48 ERROR Telegram error: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
21:21:55 ERROR Replace media error: {"ok":false,"error_code":400,"description":"Bad Request: message to edit not found"}
21:21:57 ERROR Replace media error: {"ok":false,"error_code":400,"description":"Bad Request: message to edit not found"}
21:21:58 ERROR Replace media error: {"ok":false,"error_code":400,"description":"Bad Request: message to edit not found"}
```

## Fix

`replace_telegram_media` now checks `not config.get('last_msg_id')` instead of `'last_msg_id' not in config` — catching both a missing key and a `None` value.

When `last_msg_id` is falsy, instead of returning `False`, it falls back to `sendAnimation` (new message). On success it sets `config['last_msg_id']` to the new message ID so the subsequent `update_telegram_caption` call works correctly.

The same `None`-safe guard is applied to `update_telegram_caption`.

## Tests

Four new tests in `tests/test_tasks.py`:

- `last_msg_id=None` → `sendAnimation` called, `editMessageMedia` not called, `config['last_msg_id']` updated
- `last_msg_id` key absent → same fallback
- `last_msg_id` present → normal `editMessageMedia` path unchanged
- After fallback send succeeds, caption update correctly targets the new message ID

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)