### PR TITLE
Show last 100 webhook trigger groups in live logs

### DIFF
--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -7,6 +7,7 @@ import redis
 import logging
 import requests
 from datetime import datetime
+from collections import deque
 from rq import Queue
 from flask import Flask, request, jsonify, render_template_string, redirect, url_for, flash, send_file, abort
 from db_utils import connect as sqlite_connect
@@ -179,6 +180,7 @@ init_db()
 # --- HELPERS ---
 
 _LOG_TAG_RE = re.compile(r'(\[[^\]]+\]\[[^\]]+\])')
+_WEBHOOK_TRIGGER_LIMIT = 100
 
 
 def _parse_log_line(source_name, line):
@@ -201,12 +203,23 @@ def _parse_log_line(source_name, line):
     }
 
 
+def _get_recent_trigger_tags(system_log_path):
+    recent = deque(maxlen=_WEBHOOK_TRIGGER_LIMIT)
+
+    with open(system_log_path) as f:
+        for line in f:
+            parsed = _parse_log_line("system.log", line)
+            if parsed and parsed["is_trigger"] and parsed["alert_tag"]:
+                recent.append(parsed["alert_tag"])
+
+    return list(recent)
+
+
 def get_log_entries():
     if not os.path.isdir(LOG_DIR):
         return []
 
     try:
-        entries = []
         log_files = sorted(
             name for name in os.listdir(LOG_DIR)
             if name.endswith(".log") and os.path.isfile(os.path.join(LOG_DIR, name))
@@ -214,19 +227,29 @@ def get_log_entries():
         if not log_files:
             return []
 
+        system_log_path = os.path.join(LOG_DIR, "system.log")
+        if not os.path.isfile(system_log_path):
+            return []
+
+        trigger_tags = _get_recent_trigger_tags(system_log_path)
+        if not trigger_tags:
+            return []
+
+        selected_tags = set(trigger_tags)
+        entries = []
         for name in log_files:
             path = os.path.join(LOG_DIR, name)
             with open(path) as f:
-                for line in f.readlines()[-200:]:
+                for line in f:
                     parsed = _parse_log_line(name, line)
-                    if parsed:
+                    if parsed and parsed["alert_tag"] in selected_tags:
                         entries.append(parsed)
 
         if not entries:
             return []
 
         entries.sort(key=lambda item: item["timestamp"])
-        return entries[-200:]
+        return entries
     except Exception as e:
         return [{
             "source": "system",

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -59,6 +59,36 @@ def test_get_log_entries_marks_webhook_trigger_and_alert_tag(tmp_path, monkeypat
     assert entries[1]["is_trigger"] is False
 
 
+def test_get_log_entries_keeps_last_100_trigger_groups(tmp_path, monkeypatch):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    system_lines = []
+    worker_lines = []
+    for idx in range(105):
+        tag = f"[Driveway][tag{idx:04d}]"
+        second = idx % 60
+        minute = idx // 60
+        timestamp = f"2026-04-13 12:{minute:02d}:{second:02d},000"
+        system_lines.append(f"{timestamp} - INFO - {tag} Webhook triggered. File: test-{idx}.jpg")
+        worker_lines.append(f"{timestamp} - INFO - {tag} delivery completed | phase=delivery_completed")
+
+    (log_dir / "system.log").write_text("\n".join(system_lines))
+    (log_dir / "video_delivery_worker.log").write_text("\n".join(worker_lines))
+
+    monkeypatch.setattr(wsgi, "LOG_DIR", str(log_dir))
+
+    entries = wsgi.get_log_entries()
+    tags = {entry["alert_tag"] for entry in entries}
+
+    assert "[Driveway][tag0000]" not in tags
+    assert "[Driveway][tag0004]" not in tags
+    assert "[Driveway][tag0005]" in tags
+    assert "[Driveway][tag0104]" in tags
+    assert len({entry["alert_tag"] for entry in entries if entry["is_trigger"]}) == 100
+    assert any(entry["source"] == "video_delivery_worker.log" for entry in entries)
+
+
 def test_sqlite_wal_mode_enabled(client):
     """Test that the application database is configured for WAL mode."""
     with sqlite3.connect(wsgi.DB_FILE) as conn:


### PR DESCRIPTION
Fixes the live log viewer so it shows the last 100 `Webhook triggered` alert groups instead of the last 200 raw log lines.

The backend now derives the window from the most recent 100 trigger tags in `system.log` and then includes all correlated lines for those alerts across the service log files. This prevents grouped traces from breaking once the original trigger line would otherwise fall out of a fixed 200-line tail.