### PR TITLE
Refresh BI alert lookup after OpenBVR export failures. Refresh and defer OpenBVR export retries until BI is idle

### DIFF
--- a/app/bi_export_shared.py
+++ b/app/bi_export_shared.py
@@ -22,6 +22,7 @@ DATA_DIR = os.getenv("DATA_DIR", "/app/data")
 DB_FILE = os.path.join(DATA_DIR, "configs.db")
 
 EXPORT_REQUEST_QUEUE     = "bi:export:requests"
+OPENBVR_RETRY_QUEUE      = "bi:export:openbvr:retry"
 DOWNLOAD_REQUEST_QUEUE   = "bi:download:requests"
 VIDEO_DELIVERY_QUEUE     = "bi:delivery:requests"
 ACTIVE_EXPORT_SET        = "bi:exports:active"
@@ -35,6 +36,7 @@ DOWNLOAD_TIMEOUT         = 60
 RECOVERY_PAUSE           = 15
 QUEUE_PROGRESS_LOG_INTERVAL = 15
 MAX_EXPORT_ATTEMPTS      = 2
+MAX_OPENBVR_DEFER_ATTEMPTS = 1
 MAX_RECOVERY_ATTEMPTS    = 1
 MAX_DELIVERY_ATTEMPTS    = 3
 SESSION_KEY_PREFIX       = "bi:session:"
@@ -192,6 +194,7 @@ def recommended_action_for(error_code):
         "missing_clip_path": "check_prequeue_lookup_and_bvr_clip_fallback",
         "offset_unparseable": "check_alert_filename_format_and_offset_parser",
         "openbvr_failed": "check_blue_iris_clip_integrity_and_source_bvr_path",
+        "openbvr_lookup_refresh_failed": "check_bi_alert_lookup_freshness_and_source_clip_path_after_openbvr_failure",
         "persistent_404": "check_bi_clip_endpoint_visibility_after_export_completion",
         "queue_ack_timeout": "check_bi_export_queue_acknowledgement_and_export_submission",
         "queue_poll_failed": "check_bi_queue_monitor_connectivity_and_session_validity",
@@ -322,6 +325,28 @@ def trigger_bi_recovery(restart_url, restart_token, tag):
     except Exception as exc:
         logging.error(f"{tag} BI recovery error: {safe_error_summary(exc)}")
     return False
+
+
+def bi_lookup_alert(bi_url, bi_user, bi_pass, trigger_filename, tag):
+    """
+    Look up an alert in BI's alert list using the shared session cache.
+    Returns (clip, offset, msec) or None if the alert is not present.
+    """
+    json_url = urljoin(bi_url.rstrip("/") + "/", "json")
+    sess, sid = get_session(bi_url, bi_user, bi_pass, tag)
+    if not sid:
+        raise RuntimeError("BI login failed")
+
+    alert_list = sess.post(
+        json_url,
+        json={"cmd": "alertlist", "camera": "Index", "session": sid},
+        timeout=10,
+    )
+    alert_list.raise_for_status()
+    for alert in alert_list.json().get("data", []):
+        if alert.get("file") == trigger_filename:
+            return alert.get("clip"), alert.get("offset", 0), alert.get("msec", 10000)
+    return None
 
 
 def bi_get_export_queue(sess, base_url, sid):

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -43,7 +43,7 @@ logger = setup_service_logger("bi_exporter", LOG_FILE)
 
 def _defer_openbvr_retry(req, tag, clip_path):
     active_exports = r.scard(ACTIVE_EXPORT_SET)
-    if active_exports <= 0:
+    if active_exports == 0:
         return False
 
     deferred_attempts = int(req.get("_openbvr_deferred_attempts", 0))
@@ -145,7 +145,8 @@ def _prepare_export(req, tag):
         "session": sid,
     }
 
-    if int(req.get("_openbvr_deferred_attempts", 0)) > 0:
+    refreshed_after_openbvr = int(req.get("_openbvr_refreshed_attempts", 0))
+    if int(req.get("_openbvr_deferred_attempts", 0)) > 0 or refreshed_after_openbvr > 0:
         refreshed, refresh_error = _refresh_export_request_after_openbvr(req, payload, tag)
         if not refreshed:
             return None, refresh_error
@@ -239,6 +240,27 @@ def _prepare_export(req, tag):
         if "OpenBVR failed" in str(res.get("data", {})):
             if _defer_openbvr_retry(req, tag, payload.get("path")):
                 return None, "openbvr deferred retry queued"
+            if refreshed_after_openbvr == 0:
+                req["_openbvr_refreshed_attempts"] = 1
+                refreshed, refresh_error = _refresh_export_request_after_openbvr(req, payload, tag)
+                if not refreshed:
+                    return None, refresh_error
+                er = sess.post(export_url, json=payload, timeout=10)
+                res = er.json()
+                if res.get("result") == "success":
+                    target_path, relative_uri = bi_resolve_export_target(res.get("data"), known_paths, tag)
+                    if not target_path or not relative_uri:
+                        try:
+                            queue_data = bi_get_export_queue(sess, req["bi_url"], sid)
+                            target_path, relative_uri = bi_resolve_export_target(queue_data, known_paths, tag)
+                        except Exception as exc:
+                            logger.warning(
+                                f"{tag} Failed to refresh export queue after refreshed enqueue | "
+                                f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_snapshot_refresh "
+                                f"error_code=queue_refresh_failed error={safe_error_summary(exc)}"
+                            )
+                    if target_path and relative_uri:
+                        break
 
         return None, f"BI export command failed: {res.get('result')}"
 

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -12,8 +12,11 @@ from urllib.parse import urljoin
 from bi_export_shared import (
     ACTIVE_EXPORT_SET,
     EXPORT_REQUEST_QUEUE,
+    MAX_OPENBVR_DEFER_ATTEMPTS,
     MAX_EXPORT_ATTEMPTS,
+    OPENBVR_RETRY_QUEUE,
     STALE_REQUEST_AGE,
+    bi_lookup_alert,
     bi_get_export_queue,
     bi_instance_label,
     bi_resolve_export_target,
@@ -36,6 +39,86 @@ if os.path.dirname(LOG_FILE):
     os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
 
 logger = setup_service_logger("bi_exporter", LOG_FILE)
+
+
+def _defer_openbvr_retry(req, tag, clip_path):
+    active_exports = r.scard(ACTIVE_EXPORT_SET)
+    if active_exports <= 0:
+        return False
+
+    deferred_attempts = int(req.get("_openbvr_deferred_attempts", 0))
+    if deferred_attempts >= MAX_OPENBVR_DEFER_ATTEMPTS:
+        return False
+
+    req["_openbvr_deferred_attempts"] = deferred_attempts + 1
+    req["queued_at"] = time.time()
+    queue_depth_before = r.llen(OPENBVR_RETRY_QUEUE)
+    r.rpush(OPENBVR_RETRY_QUEUE, json.dumps(req))
+    logger.warning(
+        f"{tag} Deferring OpenBVR retry until BI export queue is idle | "
+        f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_submit_deferred "
+        f"retry_reason=openbvr_failed active_exports={active_exports} "
+        f"deferred_attempt={req['_openbvr_deferred_attempts']} "
+        f"deferred_queue_depth={queue_depth_before + 1} clip_path={clip_path}"
+    )
+    return True
+
+
+def _refresh_export_request_after_openbvr(req, payload, tag):
+    trigger_filename = req.get("trigger_filename")
+    if not trigger_filename:
+        return False, "missing trigger_filename for BI alert refresh"
+
+    try:
+        result = bi_lookup_alert(
+            req["bi_url"],
+            req["bi_user"],
+            req["bi_pass"],
+            trigger_filename,
+            tag,
+        )
+    except Exception as exc:
+        logger.warning(
+            f"{tag} BI alert lookup refresh failed after OpenBVR error | "
+            f"bi_instance={bi_instance_label(req['bi_url'])} phase=prequeue_lookup "
+            f"error_code=openbvr_lookup_refresh_failed error={safe_error_summary(exc)}"
+        )
+        return False, "BI alert lookup refresh failed after OpenBVR error"
+
+    if result is None:
+        logger.warning(
+            f"{tag} BI alert lookup refresh found no matching alert after OpenBVR error | "
+            f"bi_instance={bi_instance_label(req['bi_url'])} phase=prequeue_lookup "
+            f"error_code=openbvr_lookup_refresh_failed lookup_result=refresh_not_found_after_openbvr_failure "
+            f"trigger_filename={trigger_filename}"
+        )
+        return False, "BI alert lookup refresh found no matching alert after OpenBVR error"
+
+    clip_path, offset, duration = result
+    req["clip_path"] = clip_path
+    req["offset"] = offset
+    req["duration"] = duration
+
+    refreshed_path = clip_path if clip_path.startswith("@") else f"@{clip_path}"
+    if not refreshed_path.endswith(".bvr"):
+        refreshed_path += ".bvr"
+
+    payload["path"] = refreshed_path
+    payload["startms"] = int(offset or 0)
+    payload["msec"] = int(duration or 10000)
+
+    logger.info(
+        f"{tag} BI alert lookup refreshed after OpenBVR error | "
+        f"bi_instance={bi_instance_label(req['bi_url'])} phase=prequeue_lookup "
+        f"lookup_result=refreshed_after_openbvr_failure clip_path={clip_path} "
+        f"offset={offset} duration={duration}"
+    )
+    logger.info(
+        f"{tag} Retrying BI export with refreshed alert metadata | "
+        f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_submit_retry "
+        f"retry_reason=openbvr_failed clip_path={clip_path} offset={offset} duration={duration}"
+    )
+    return True, None
 
 
 def _prepare_export(req, tag):
@@ -146,7 +229,14 @@ def _prepare_export(req, tag):
                 f"error_code=openbvr_failed"
             )
             time.sleep(2)
+            refreshed, refresh_error = _refresh_export_request_after_openbvr(req, payload, tag)
+            if not refreshed:
+                return None, refresh_error
             continue
+
+        if "OpenBVR failed" in str(res.get("data", {})):
+            if _defer_openbvr_retry(req, tag, payload.get("path")):
+                return None, "openbvr deferred retry queued"
 
         return None, f"BI export command failed: {res.get('result')}"
 
@@ -226,6 +316,10 @@ def _process_request(raw):
             error_code = "missing_clip_path"
         elif error_msg == "missing path/uri in BI response":
             error_code = "missing_export_target"
+        elif error_msg and error_msg.startswith("BI alert lookup refresh"):
+            error_code = "openbvr_lookup_refresh_failed"
+        elif error_msg == "openbvr deferred retry queued":
+            return
         log_terminal_diagnosis(
             logger,
             tag,
@@ -258,6 +352,14 @@ def run_exporter():
         item = r.blpop(EXPORT_REQUEST_QUEUE, timeout=5)
         if item:
             _process_request(item[1])
+            continue
+
+        if r.scard(ACTIVE_EXPORT_SET) != 0:
+            continue
+
+        deferred_item = r.blpop(OPENBVR_RETRY_QUEUE, timeout=1)
+        if deferred_item:
+            _process_request(deferred_item[1])
 
 
 if __name__ == "__main__":

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -145,6 +145,11 @@ def _prepare_export(req, tag):
         "session": sid,
     }
 
+    if int(req.get("_openbvr_deferred_attempts", 0)) > 0:
+        refreshed, refresh_error = _refresh_export_request_after_openbvr(req, payload, tag)
+        if not refreshed:
+            return None, refresh_error
+
     current_queue = []
     known_paths = set()
     try:
@@ -229,9 +234,6 @@ def _prepare_export(req, tag):
                 f"error_code=openbvr_failed"
             )
             time.sleep(2)
-            refreshed, refresh_error = _refresh_export_request_after_openbvr(req, payload, tag)
-            if not refreshed:
-                return None, refresh_error
             continue
 
         if "OpenBVR failed" in str(res.get("data", {})):

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -11,11 +11,10 @@ import subprocess
 import redis
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from urllib.parse import urljoin
 from logging.handlers import RotatingFileHandler
 from PIL import Image
 from datetime import datetime, timedelta
-from bi_export_shared import EXPORT_REQUEST_QUEUE, bi_lookup_alert, get_session, recommended_action_for
+from bi_export_shared import EXPORT_REQUEST_QUEUE, bi_lookup_alert, recommended_action_for
 from db_utils import connect as sqlite_connect
 
 # --- LOGGING SETUP ---

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -15,7 +15,7 @@ from urllib.parse import urljoin
 from logging.handlers import RotatingFileHandler
 from PIL import Image
 from datetime import datetime, timedelta
-from bi_export_shared import EXPORT_REQUEST_QUEUE, get_session, recommended_action_for
+from bi_export_shared import EXPORT_REQUEST_QUEUE, bi_lookup_alert, get_session, recommended_action_for
 from db_utils import connect as sqlite_connect
 
 # --- LOGGING SETUP ---
@@ -906,23 +906,6 @@ def _parse_offset_ms(filename):
     return int(m.group(1)) if m else None
 
 
-def _bi_lookup_alert(bi_url, bi_user, bi_pass, trigger_filename, tag):
-    """
-    Reuse the shared BI session and look up clip details for trigger_filename
-    immediately, while the alert is guaranteed fresh in the alertlist.
-    """
-    json_url = urljoin(bi_url.rstrip("/") + "/", "json")
-    sess, sid = get_session(bi_url, bi_user, bi_pass, tag)
-    if not sid:
-        raise RuntimeError("BI login failed")
-    al = sess.post(json_url, json={"cmd": "alertlist", "camera": "Index", "session": sid}, timeout=10)
-    al.raise_for_status()
-    for alert in al.json().get("data", []):
-        if alert.get("file") == trigger_filename:
-            return alert.get("clip"), alert.get("offset", 0), alert.get("msec", 10000)
-    return None
-
-
 def build_bi_export_payload(config, output_path, tag, delivery_context=None):
     """Build the staged BI export request payload after resolving clip metadata."""
     request_id = str(uuid.uuid4())
@@ -933,7 +916,7 @@ def build_bi_export_payload(config, output_path, tag, delivery_context=None):
     bvr_clip = config.get("bvr_clip", "")
     if trigger_filename and config.get("bi_url") and config.get("bi_user"):
         try:
-            result = _bi_lookup_alert(
+            result = bi_lookup_alert(
                 config["bi_url"], config["bi_user"], config["bi_pass"],
                 trigger_filename, tag,
             )

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -810,3 +810,168 @@ class TestVideoDeliveryWorker:
 
         stored = bi_export_shared.load_job(job["request_id"])
         assert stored["delivery_context"]["config"]["last_msg_id"] == 888
+
+
+def test_refreshes_alert_lookup_after_openbvr_failed(monkeypatch):
+    payload = _request_payload(
+        clip_path="@clip/original",
+        offset=10,
+        duration=10000,
+        trigger_filename="alert.jpg",
+    )
+
+    monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        bi_exporter,
+        "bi_lookup_alert",
+        lambda *args, **kwargs: ("@clip/refreshed", 222, 33333),
+    )
+
+    posted = []
+
+    class FakeSession:
+        def post(self, url, json=None, timeout=None):
+            posted.append(dict(json))
+
+            class R:
+                def __init__(self, body):
+                    self._body = body
+
+                def json(self):
+                    return self._body
+
+            if len(posted) == 1:
+                return R({"result": "fail", "data": {"reason": "OpenBVR failed"}})
+            return R({"result": "success", "data": {"path": "@22842", "uri": "Clipboard\\new.mp4"}})
+
+    monkeypatch.setattr(bi_exporter, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+
+    job, error = bi_exporter._prepare_export(payload, "[T]")
+
+    assert error is None
+    assert job["request"]["clip_path"] == "@clip/refreshed"
+    assert job["request"]["offset"] == 222
+    assert job["request"]["duration"] == 33333
+    assert posted[0]["path"] == "@clip/original.bvr"
+    assert posted[1]["path"] == "@clip/refreshed.bvr"
+    assert posted[1]["startms"] == 222
+    assert posted[1]["msec"] == 33333
+
+
+def test_openbvr_refresh_failure_returns_specific_error(monkeypatch):
+    payload = _request_payload(
+        clip_path="@clip/original",
+        offset=10,
+        duration=10000,
+        trigger_filename="alert.jpg",
+    )
+
+    monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
+    monkeypatch.setattr(bi_exporter, "bi_lookup_alert", lambda *args, **kwargs: None)
+
+    class FakeSession:
+        def post(self, url, json=None, timeout=None):
+            class R:
+                def json(self):
+                    return {"result": "fail", "data": {"reason": "OpenBVR failed"}}
+
+            return R()
+
+    monkeypatch.setattr(bi_exporter, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+
+    job, error = bi_exporter._prepare_export(payload, "[T]")
+
+    assert job is None
+    assert error == "BI alert lookup refresh found no matching alert after OpenBVR error"
+
+
+def test_defers_openbvr_retry_when_active_exports_running(monkeypatch):
+    payload = _request_payload(
+        clip_path="@clip/original",
+        offset=10,
+        duration=10000,
+        trigger_filename="alert.jpg",
+    )
+
+    monkeypatch.setattr(
+        bi_exporter,
+        "bi_lookup_alert",
+        lambda *args, **kwargs: ("@clip/refreshed", 222, 33333),
+    )
+    monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
+
+    queued = {}
+
+    class FakeRedis:
+        def scard(self, key):
+            assert key == bi_export_shared.ACTIVE_EXPORT_SET
+            return 2
+
+        def llen(self, key):
+            assert key == bi_export_shared.OPENBVR_RETRY_QUEUE
+            return 0
+
+        def rpush(self, key, value):
+            queued["key"] = key
+            queued["value"] = json.loads(value)
+            return 1
+
+    class FakeSession:
+        def post(self, url, json=None, timeout=None):
+            class R:
+                def json(self):
+                    return {"result": "fail", "data": {"reason": "OpenBVR failed"}}
+
+            return R()
+
+    monkeypatch.setattr(bi_exporter, "r", FakeRedis())
+    monkeypatch.setattr(bi_exporter, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+
+    job, error = bi_exporter._prepare_export(payload, "[T]")
+
+    assert job is None
+    assert error == "openbvr deferred retry queued"
+    assert queued["key"] == bi_export_shared.OPENBVR_RETRY_QUEUE
+    assert queued["value"]["clip_path"] == "@clip/refreshed"
+    assert queued["value"]["_openbvr_deferred_attempts"] == 1
+
+
+def test_run_exporter_only_drains_openbvr_retry_queue_when_idle(monkeypatch):
+    calls = []
+
+    class FakeRedis:
+        def __init__(self):
+            self.export_blpop_calls = 0
+
+        def blpop(self, key, timeout=0):
+            calls.append(("blpop", key, timeout))
+            if key == bi_export_shared.EXPORT_REQUEST_QUEUE:
+                self.export_blpop_calls += 1
+                if self.export_blpop_calls == 1:
+                    return None
+                raise RuntimeError("stop")
+            if key == bi_export_shared.OPENBVR_RETRY_QUEUE:
+                return (key, b'{"request_id":"deferred"}')
+            raise AssertionError(f"unexpected queue {key}")
+
+        def scard(self, key):
+            calls.append(("scard", key))
+            assert key == bi_export_shared.ACTIVE_EXPORT_SET
+            return 0
+
+    monkeypatch.setattr(bi_exporter, "r", FakeRedis())
+    monkeypatch.setattr(bi_exporter, "start_heartbeat_thread", lambda *_args, **_kwargs: None)
+
+    def fake_process(raw):
+        calls.append(("process", raw))
+
+    monkeypatch.setattr(bi_exporter, "_process_request", fake_process)
+
+    try:
+        bi_exporter.run_exporter()
+    except RuntimeError as exc:
+        assert str(exc) == "stop"
+
+    assert ("scard", bi_export_shared.ACTIVE_EXPORT_SET) in calls
+    assert ("blpop", bi_export_shared.OPENBVR_RETRY_QUEUE, 1) in calls
+    assert ("process", b'{"request_id":"deferred"}') in calls

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -812,12 +812,13 @@ class TestVideoDeliveryWorker:
         assert stored["delivery_context"]["config"]["last_msg_id"] == 888
 
 
-def test_refreshes_alert_lookup_after_openbvr_failed(monkeypatch):
+def test_deferred_openbvr_retry_refreshes_alert_lookup_before_retry(monkeypatch):
     payload = _request_payload(
         clip_path="@clip/original",
         offset=10,
         duration=10000,
         trigger_filename="alert.jpg",
+        _openbvr_deferred_attempts=1,
     )
 
     monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
@@ -852,18 +853,18 @@ def test_refreshes_alert_lookup_after_openbvr_failed(monkeypatch):
     assert job["request"]["clip_path"] == "@clip/refreshed"
     assert job["request"]["offset"] == 222
     assert job["request"]["duration"] == 33333
-    assert posted[0]["path"] == "@clip/original.bvr"
-    assert posted[1]["path"] == "@clip/refreshed.bvr"
-    assert posted[1]["startms"] == 222
-    assert posted[1]["msec"] == 33333
+    assert posted[0]["path"] == "@clip/refreshed.bvr"
+    assert posted[0]["startms"] == 222
+    assert posted[0]["msec"] == 33333
 
 
-def test_openbvr_refresh_failure_returns_specific_error(monkeypatch):
+def test_deferred_openbvr_refresh_failure_returns_specific_error(monkeypatch):
     payload = _request_payload(
         clip_path="@clip/original",
         offset=10,
         duration=10000,
         trigger_filename="alert.jpg",
+        _openbvr_deferred_attempts=1,
     )
 
     monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
@@ -883,6 +884,42 @@ def test_openbvr_refresh_failure_returns_specific_error(monkeypatch):
 
     assert job is None
     assert error == "BI alert lookup refresh found no matching alert after OpenBVR error"
+
+
+def test_openbvr_immediate_retry_keeps_original_metadata(monkeypatch):
+    payload = _request_payload(
+        clip_path="@clip/original",
+        offset=10,
+        duration=10000,
+        trigger_filename="alert.jpg",
+    )
+
+    monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
+
+    posted = []
+
+    class FakeSession:
+        def post(self, url, json=None, timeout=None):
+            posted.append(dict(json))
+
+            class R:
+                def json(self):
+                    if len(posted) == 1:
+                        return {"result": "fail", "data": {"reason": "OpenBVR failed"}}
+                    return {"result": "success", "data": {"path": "@22842", "uri": "Clipboard\\new.mp4"}}
+
+            return R()
+
+    monkeypatch.setattr(bi_exporter, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+
+    job, error = bi_exporter._prepare_export(payload, "[T]")
+
+    assert error is None
+    assert job["request"]["clip_path"] == "@clip/original"
+    assert posted[0]["path"] == "@clip/original.bvr"
+    assert posted[1]["path"] == "@clip/original.bvr"
+    assert posted[1]["startms"] == 10
+    assert posted[1]["msec"] == 10000
 
 
 def test_defers_openbvr_retry_when_active_exports_running(monkeypatch):
@@ -932,7 +969,7 @@ def test_defers_openbvr_retry_when_active_exports_running(monkeypatch):
     assert job is None
     assert error == "openbvr deferred retry queued"
     assert queued["key"] == bi_export_shared.OPENBVR_RETRY_QUEUE
-    assert queued["value"]["clip_path"] == "@clip/refreshed"
+    assert queued["value"]["clip_path"] == "@clip/original"
     assert queued["value"]["_openbvr_deferred_attempts"] == 1
 
 

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -922,6 +922,63 @@ def test_openbvr_immediate_retry_keeps_original_metadata(monkeypatch):
     assert posted[1]["msec"] == 10000
 
 
+def test_openbvr_idle_second_failure_refreshes_and_retries(monkeypatch):
+    payload = _request_payload(
+        clip_path="@clip/original",
+        offset=10,
+        duration=10000,
+        trigger_filename="alert.jpg",
+    )
+
+    monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        bi_exporter,
+        "bi_lookup_alert",
+        lambda *args, **kwargs: ("@clip/refreshed", 222, 33333),
+    )
+
+    class FakeRedis:
+        def scard(self, key):
+            assert key == bi_export_shared.ACTIVE_EXPORT_SET
+            return 0
+
+        def llen(self, key):
+            raise AssertionError("deferred queue depth should not be checked when idle")
+
+        def rpush(self, key, value):
+            raise AssertionError("should not defer when already idle")
+
+    posted = []
+
+    class FakeSession:
+        def post(self, url, json=None, timeout=None):
+            posted.append(dict(json))
+
+            class R:
+                def __init__(self, body):
+                    self._body = body
+
+                def json(self):
+                    return self._body
+
+            if len(posted) < 3:
+                return R({"result": "fail", "data": {"reason": "OpenBVR failed"}})
+            return R({"result": "success", "data": {"path": "@22842", "uri": "Clipboard\\new.mp4"}})
+
+    monkeypatch.setattr(bi_exporter, "r", FakeRedis())
+    monkeypatch.setattr(bi_exporter, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+
+    job, error = bi_exporter._prepare_export(payload, "[T]")
+
+    assert error is None
+    assert job["request"]["clip_path"] == "@clip/refreshed"
+    assert posted[0]["path"] == "@clip/original.bvr"
+    assert posted[1]["path"] == "@clip/original.bvr"
+    assert posted[2]["path"] == "@clip/refreshed.bvr"
+    assert posted[2]["startms"] == 222
+    assert posted[2]["msec"] == 33333
+
+
 def test_defers_openbvr_retry_when_active_exports_running(monkeypatch):
     payload = _request_payload(
         clip_path="@clip/original",


### PR DESCRIPTION
  Fixes #129

  When Blue Iris returns `OpenBVR failed`, the exporter now retries once after 2 seconds using the original clip metadata.

  If that second submission still fails and there are active BI exports running, the request is deferred into a dedicated retry queue instead of failing immediately.

  Deferred `OpenBVR` retries are only processed when the BI export set is idle. At that point, the exporter reruns BI alert lookup using the alert filename, refreshes the clip path /offset /duration, and retries export with the refreshed metadata.

  This keeps transient clip-open failures from competing with active exports during busy periods, while still giving the request one later attempt with freshly resolved BI alert metadata.

  Also adds targeted unit coverage for:
  - immediate retry keeping original metadata
  - deferred retry refreshing metadata before retry
  - specific refresh-failure handling
  - defer-under-load behavior
  - idle-only deferred retry draining