### PR TITLE
Fix MJPG overlay sizing within screen bounds

### DIFF
--- a/android-tv-overlay/app/src/main/java/nl/rogro82/pipup/PopupView.kt
+++ b/android-tv-overlay/app/src/main/java/nl/rogro82/pipup/PopupView.kt
@@ -246,8 +246,9 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                                     val bmp = BitmapFactory.decodeByteArray(jpegBytes, 0, jpegBytes.size)
                                     if (bmp != null) {
                                         mainHandler.post {
-                                            val targetHeight = scaledHeight(media.width, bmp.width, bmp.height)
-                                            imageLayoutParams?.height = targetHeight
+                                            val fitted = fittedDimensions(frame, bmp.width, bmp.height)
+                                            imageLayoutParams?.width = fitted.first
+                                            imageLayoutParams?.height = fitted.second
                                             imageView?.layoutParams = imageLayoutParams
                                             imageView?.setImageBitmap(bmp)
                                             this@Mjpeg.visibility = View.VISIBLE
@@ -270,6 +271,22 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
             running = false
             thread?.interrupt()
             imageView?.setImageDrawable(null)
+        }
+
+        private fun fittedDimensions(frame: FrameLayout, sourceWidth: Int, sourceHeight: Int): Pair<Int, Int> {
+            val availableWidth = frame.width
+                .takeIf { it > 0 }
+                ?: media.width
+            val availableHeight = frame.height
+                .takeIf { it > 0 }
+                ?: resources.displayMetrics.heightPixels
+
+            return fitWithinBounds(
+                availableWidth,
+                availableHeight,
+                sourceWidth,
+                sourceHeight,
+            )
         }
     }
 
@@ -321,6 +338,26 @@ sealed class PopupView(context: Context, val popup: PopupProps) : LinearLayout(c
                 return ViewGroup.LayoutParams.WRAP_CONTENT
             }
             return ((targetWidth.toFloat() / sourceWidth) * sourceHeight).toInt().coerceAtLeast(1)
+        }
+
+        internal fun fitWithinBounds(
+            maxWidth: Int,
+            maxHeight: Int,
+            sourceWidth: Int,
+            sourceHeight: Int,
+        ): Pair<Int, Int> {
+            if (maxWidth <= 0 || maxHeight <= 0 || sourceWidth <= 0 || sourceHeight <= 0) {
+                return Pair(maxWidth.coerceAtLeast(1), ViewGroup.LayoutParams.WRAP_CONTENT)
+            }
+
+            val widthRatio = maxWidth.toFloat() / sourceWidth
+            val heightRatio = maxHeight.toFloat() / sourceHeight
+            val scale = minOf(widthRatio, heightRatio)
+
+            return Pair(
+                (sourceWidth * scale).toInt().coerceIn(1, maxWidth),
+                (sourceHeight * scale).toInt().coerceIn(1, maxHeight),
+            )
         }
 
         fun build(context: Context, popup: PopupProps): PopupView

--- a/android-tv-overlay/app/src/test/java/nl/rogro82/pipup/PopupViewTest.kt
+++ b/android-tv-overlay/app/src/test/java/nl/rogro82/pipup/PopupViewTest.kt
@@ -18,4 +18,12 @@ class PopupViewTest {
             PopupView.scaledHeight(480, 0, 1080)
         )
     }
+
+    @Test
+    fun fitWithinBounds_limitsByHeightWhenWidthOnlyScalingWouldOverflow() {
+        val fitted = PopupView.fitWithinBounds(1920, 1080, 1440, 2560)
+
+        assertEquals(607, fitted.first)
+        assertEquals(1080, fitted.second)
+    }
 }


### PR DESCRIPTION
## Summary
- fit MJPG popup rendering within the available popup frame bounds
- prevent centered/full-screen MJPG overlays from clipping the bottom of the stream
- add a unit test covering height-limited aspect-ratio fitting

## Verification
- `cd android-tv-overlay && ./gradlew testDebugUnitTest assembleDebug`
