### PR TITLE
Add TV group priority controls

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -1121,35 +1121,41 @@ def process_alert(image_path, config):
         if _tv_eligible:
             import tv_delivery
             logger.info(f"{tag} TV dispatch: camera={config.get('name')!r} group={config.get('tv_group')!r} stream_type={_tv_stream_type!r}")
-            tv_result = tv_delivery.dispatch_tv_alert(
-                {
-                    "id": config.get("id"),
-                    "name": config.get("name"),
-                    "request_id": config.get("request_id"),
-                    "tv_rtsp_url": config.get("tv_rtsp_url"),
-                    "tv_duration_seconds": config.get("tv_duration_seconds"),
-                    "tv_group": config.get("tv_group"),
-                    "tv_mute_audio": config.get("tv_mute_audio"),
-                    "tv_stream_type": _tv_stream_type,
-                    "bi_url": config.get("bi_url"),
-                    "bi_user": config.get("bi_user"),
-                    "bi_pass": config.get("bi_pass"),
-                },
-                tag,
-            )
-            if tv_result.get("skipped"):
-                if _tv_stream_type == "mjpg":
-                    logger.info(f"{tag} TV dispatch skipped (no MJPG proxy URL)")
-                else:
-                    logger.info(f"{tag} TV dispatch skipped (no RTSP URL)")
-            elif tv_result.get("error"):
-                logger.warning(f"{tag} TV dispatch error: {tv_result['error']}")
+            should_dispatch, active_winner = tv_delivery.should_dispatch_group_alert(config)
+            if not should_dispatch:
+                logger.info(
+                    f"{tag} TV dispatch skipped (higher-priority camera active: {active_winner.get('name')!r})"
+                )
             else:
-                delivered = tv_result.get("delivered", [])
-                failed = tv_result.get("failed", [])
-                logger.info(f"{tag} TV dispatch: delivered={len(delivered)} failed={len(failed)}")
-                if failed:
-                    logger.warning(f"{tag} TV dispatch failed TV IDs: {failed}")
+                tv_result = tv_delivery.dispatch_tv_alert(
+                    {
+                        "id": config.get("id"),
+                        "name": config.get("name"),
+                        "request_id": config.get("request_id"),
+                        "tv_rtsp_url": config.get("tv_rtsp_url"),
+                        "tv_duration_seconds": config.get("tv_duration_seconds"),
+                        "tv_group": config.get("tv_group"),
+                        "tv_mute_audio": config.get("tv_mute_audio"),
+                        "tv_stream_type": _tv_stream_type,
+                        "bi_url": config.get("bi_url"),
+                        "bi_user": config.get("bi_user"),
+                        "bi_pass": config.get("bi_pass"),
+                    },
+                    tag,
+                )
+                if tv_result.get("skipped"):
+                    if _tv_stream_type == "mjpg":
+                        logger.info(f"{tag} TV dispatch skipped (no MJPG proxy URL)")
+                    else:
+                        logger.info(f"{tag} TV dispatch skipped (no RTSP URL)")
+                elif tv_result.get("error"):
+                    logger.warning(f"{tag} TV dispatch error: {tv_result['error']}")
+                else:
+                    delivered = tv_result.get("delivered", [])
+                    failed = tv_result.get("failed", [])
+                    logger.info(f"{tag} TV dispatch: delivered={len(delivered)} failed={len(failed)}")
+                    if failed:
+                        logger.warning(f"{tag} TV dispatch failed TV IDs: {failed}")
 
         ai_text = analyze_image_parallel(config, encoded, prompt) if encoded else None
 

--- a/app/tv_delivery.py
+++ b/app/tv_delivery.py
@@ -8,6 +8,7 @@ import secrets
 import sqlite3
 import time
 import uuid
+from datetime import datetime
 
 import requests
 
@@ -392,35 +393,115 @@ def get_group_priority_ids(group_name):
     return [row["camera_id"] for row in rows if row["camera_id"]]
 
 
-def resolve_group_winner(group_name, triggered_configs):
-    priority_ids = get_group_priority_ids(group_name)
-    if not priority_ids:
-        return None
+def _config_has_tv_stream(config):
+    stream_type = config.get("tv_stream_type") or "rtsp"
+    return (
+        int(config.get("tv_push_enabled") or 0) == 1
+        and (
+            (stream_type == "rtsp" and config.get("tv_rtsp_url"))
+            or (stream_type == "mjpg" and config.get("bi_url"))
+        )
+    )
 
+
+def _ordered_group_configs(group_name, candidate_configs):
+    priority_ids = get_group_priority_ids(group_name)
+    candidate_by_id = {
+        config.get("id"): config
+        for config in candidate_configs
+        if config.get("id")
+    }
+    ordered = []
+    seen = set()
+
+    for camera_id in priority_ids:
+        config = candidate_by_id.get(camera_id)
+        if config:
+            ordered.append(config)
+            seen.add(camera_id)
+
+    for config in sorted(
+        candidate_configs,
+        key=lambda item: ((item.get("name") or "").lower(), item.get("id") or ""),
+    ):
+        camera_id = config.get("id")
+        if camera_id and camera_id not in seen:
+            ordered.append(config)
+            seen.add(camera_id)
+
+    return ordered
+
+
+def resolve_group_winner(group_name, triggered_configs):
     eligible_configs = [
         config
         for config in triggered_configs
-        if int(config.get("tv_push_enabled") or 0) == 1
-        and (
-            config.get("tv_rtsp_url")
-            or ((config.get("tv_stream_type") or "rtsp") == "mjpg" and config.get("bi_url"))
-        )
+        if _config_has_tv_stream(config)
     ]
     if not eligible_configs:
         return None
 
-    eligible_by_identifier = {}
-    for config in eligible_configs:
-        camera_id = config.get("id")
-        if camera_id and camera_id not in eligible_by_identifier:
-            eligible_by_identifier[camera_id] = config
+    ordered_configs = _ordered_group_configs(group_name, eligible_configs)
+    return ordered_configs[0] if ordered_configs else None
 
-    for camera_id in priority_ids:
-        winner = eligible_by_identifier.get(camera_id)
-        if winner:
-            return winner
 
-    return None
+def _parse_last_triggered(value):
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        return value
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+def _is_group_camera_active(config, now_timestamp):
+    if not _config_has_tv_stream(config):
+        return False
+
+    triggered_at = _parse_last_triggered(config.get("last_triggered"))
+    if not triggered_at:
+        return False
+
+    try:
+        duration = int(config.get("tv_duration_seconds") or 0)
+    except (TypeError, ValueError):
+        duration = 0
+    if duration <= 0:
+        return False
+
+    return triggered_at.timestamp() + duration >= now_timestamp
+
+
+def should_dispatch_group_alert(config, now_timestamp=None):
+    group_name = (config.get("tv_group") or "").strip()
+    if not group_name:
+        return True, config
+
+    if now_timestamp is None:
+        now_timestamp = time.time()
+
+    with get_db_connection() as conn:
+        rows = conn.execute(
+            """
+            SELECT id, name, tv_push_enabled, tv_rtsp_url, tv_duration_seconds,
+                   tv_group, tv_stream_type, bi_url, last_triggered
+            FROM configs
+            WHERE tv_group=?
+            """,
+            (group_name,),
+        ).fetchall()
+
+    active_configs = [dict(row) for row in rows if _is_group_camera_active(dict(row), now_timestamp)]
+    current_id = config.get("id")
+    if current_id and current_id not in {item.get("id") for item in active_configs}:
+        active_configs.append(dict(config))
+
+    winner = resolve_group_winner(group_name, active_configs)
+    if not winner:
+        return True, config
+    return winner.get("id") == current_id, winner
 
 
 def get_paired_tv(tv_id):

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -471,6 +471,50 @@ def _load_tv_target_ids(camera_id, camera_name):
     return [row["tv_id"] for row in rows if row["tv_id"]]
 
 
+def _build_tv_group_priority_groups(configs):
+    from tv_delivery import get_group_priority_ids
+
+    grouped = {}
+    for config in configs:
+        group_name = (config.get("tv_group") or "").strip()
+        if not group_name:
+            continue
+        grouped.setdefault(group_name, []).append(
+            {
+                "id": config["id"],
+                "name": config["name"],
+                "tv_push_enabled": bool(int(config.get("tv_push_enabled") or 0)),
+                "stream_type": config.get("tv_stream_type") or "rtsp",
+                "has_stream": bool(
+                    config.get("tv_rtsp_url")
+                    or ((config.get("tv_stream_type") or "rtsp") == "mjpg" and config.get("bi_url"))
+                ),
+            }
+        )
+
+    groups = []
+    for group_name, cameras in grouped.items():
+        saved_ids = get_group_priority_ids(group_name)
+        cameras_by_id = {camera["id"]: camera for camera in cameras}
+        ordered = []
+        seen = set()
+
+        for camera_id in saved_ids:
+            camera = cameras_by_id.get(camera_id)
+            if camera:
+                ordered.append(camera)
+                seen.add(camera_id)
+
+        for camera in sorted(cameras, key=lambda item: (item["name"].lower(), item["id"])):
+            if camera["id"] not in seen:
+                ordered.append(camera)
+                seen.add(camera["id"])
+
+        groups.append({"name": group_name, "cameras": ordered})
+
+    return sorted(groups, key=lambda item: item["name"].lower())
+
+
 def _save_tv_targets(camera_id, camera_name, tv_ids):
     with get_db_connection() as conn:
         conn.execute(
@@ -1047,8 +1091,47 @@ HTML_TEMPLATE = r"""
                 <div class="card h-100">
                     <div class="card-body">
                         <h5 class="card-title">TV Group Priorities</h5>
-                        <p class="text-muted small">Grouped cameras can share a TV target. Drag-and-drop ordering is still pending; this release includes the persistence API and placeholder panel.</p>
-                        <div id="tv-group-priority-root" class="text-muted">Priority management UI is available in this feature branch, but the drag-and-drop editor is not finalized yet.</div>
+                        <p class="text-muted small">Drag cameras into the order you want the TV to prefer when multiple cameras from the same group are active at the same time.</p>
+                        {% if tv_group_priority_groups %}
+                        <div id="tv-group-priority-root" class="d-grid gap-3">
+                            {% for group in tv_group_priority_groups %}
+                            <section class="border rounded p-3 tv-group-priority-card" data-group-name="{{ group.name }}">
+                                <div class="d-flex justify-content-between align-items-center gap-3 mb-2">
+                                    <div>
+                                        <h6 class="mb-1">{{ group.name }}</h6>
+                                        <p class="text-muted small mb-0">Top item wins within this group. Different groups still replace each other by most recent trigger.</p>
+                                    </div>
+                                    <div class="text-end">
+                                        <button class="btn btn-sm btn-primary" type="button" onclick="saveTvGroupPriority('{{ group.name|e }}', this)" disabled>Save order</button>
+                                        <div class="small text-muted mt-1 tv-group-priority-status">Saved</div>
+                                    </div>
+                                </div>
+                                <div class="list-group tv-group-priority-list" data-group-name="{{ group.name }}">
+                                    {% for camera in group.cameras %}
+                                    <div class="list-group-item d-flex justify-content-between align-items-center gap-3 tv-group-priority-item" data-camera-id="{{ camera.id }}" draggable="true">
+                                        <div class="d-flex align-items-center gap-3">
+                                            <span class="text-muted" aria-hidden="true">↕</span>
+                                            <div>
+                                                <div>{{ camera.name }}</div>
+                                                <div class="small text-muted">{{ camera.stream_type|upper }}{% if not camera.has_stream %} • no stream configured{% endif %}</div>
+                                            </div>
+                                        </div>
+                                        <div class="d-flex gap-2 flex-wrap justify-content-end">
+                                            {% if camera.tv_push_enabled %}
+                                            <span class="badge bg-primary">TV enabled</span>
+                                            {% else %}
+                                            <span class="badge bg-secondary">TV disabled</span>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                    {% endfor %}
+                                </div>
+                            </section>
+                            {% endfor %}
+                        </div>
+                        {% else %}
+                        <div id="tv-group-priority-root" class="text-muted">Assign at least one camera to a TV group to manage priority order here.</div>
+                        {% endif %}
                     </div>
                 </div>
             </div>
@@ -1544,6 +1627,67 @@ async function submitTvPairing(event){
     }
     return false;
 }
+function markTvGroupPriorityDirty(groupCard, message='Unsaved changes'){
+    if(!groupCard)return;
+    const button=groupCard.querySelector('button[onclick^="saveTvGroupPriority"]');
+    const status=groupCard.querySelector('.tv-group-priority-status');
+    if(button)button.disabled=false;
+    if(status){status.textContent=message;status.classList.remove('text-success');status.classList.add('text-muted');}
+}
+function initTvGroupPriorityEditor(){
+    const root=document.getElementById('tv-group-priority-root');
+    if(!root)return;
+    let draggedItem=null;
+    root.querySelectorAll('.tv-group-priority-item').forEach(item=>{
+        item.addEventListener('dragstart',()=>{
+            draggedItem=item;
+            item.classList.add('opacity-50');
+        });
+        item.addEventListener('dragend',()=>{
+            item.classList.remove('opacity-50');
+            draggedItem=null;
+        });
+    });
+    root.querySelectorAll('.tv-group-priority-list').forEach(list=>{
+        list.addEventListener('dragover',event=>{
+            event.preventDefault();
+            const afterElement=[...list.querySelectorAll('.tv-group-priority-item:not(.opacity-50)')].find(child=>{
+                const box=child.getBoundingClientRect();
+                return event.clientY < box.top + (box.height / 2);
+            });
+            if(!draggedItem)return;
+            if(afterElement){list.insertBefore(draggedItem, afterElement);}else{list.appendChild(draggedItem);}
+        });
+        list.addEventListener('drop',event=>{
+            event.preventDefault();
+            markTvGroupPriorityDirty(list.closest('.tv-group-priority-card'));
+        });
+    });
+}
+async function saveTvGroupPriority(groupName, btn){
+    const groupCard=btn.closest('.tv-group-priority-card');
+    const status=groupCard?.querySelector('.tv-group-priority-status');
+    const list=groupCard?.querySelector('.tv-group-priority-list');
+    if(!list)return;
+    const cameraIds=[...list.querySelectorAll('.tv-group-priority-item')].map(item=>item.dataset.cameraId).filter(Boolean);
+    btn.disabled=true;
+    if(status){status.textContent='Saving...';status.classList.remove('text-success');status.classList.add('text-muted');}
+    try{
+        const response=await fetch('/tv/groups/'+encodeURIComponent(groupName)+'/priority',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({camera_ids:cameraIds}),
+        });
+        if(!response.ok){
+            throw new Error('Save failed');
+        }
+        if(status){status.textContent='Saved';status.classList.remove('text-muted');status.classList.add('text-success');}
+    }catch(_err){
+        if(status){status.textContent='Save failed';status.classList.remove('text-success');status.classList.add('text-muted');}
+        btn.disabled=false;
+        return;
+    }
+}
 function openEditModal(c){
     document.getElementById('edit_name').value=c.name;
     document.getElementById('edit_gemini_key').value=c.gemini_key;
@@ -1586,6 +1730,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     const logSourceFilter=document.getElementById('logSourceFilter');
     if(logSourceFilter)logSourceFilter.addEventListener('change',renderLogs);
     renderLogs();
+    initTvGroupPriorityEditor();
     function relativeTime(ts){const diff=Math.floor((Date.now()-new Date(ts.replace(' ','T')))/1000);if(diff<60)return diff+'s ago';if(diff<3600)return Math.floor(diff/60)+'m ago';if(diff<86400)return Math.floor(diff/3600)+'h ago';return Math.floor(diff/86400)+'d ago';}
     document.querySelectorAll('.last-seen[data-ts]').forEach(el=>{el.textContent='Last triggered: '+relativeTime(el.dataset.ts);el.title=el.dataset.ts;});
     fetch('/api/check-update').then(r=>r.json()).then(d=>{
@@ -1633,6 +1778,7 @@ def index():
     caption_mode = get_caption_mode(primary_chat_id) if primary_chat_id else None
     known_plates = load_known_plates()
     global_settings = get_global_settings()
+    tv_group_priority_groups = _build_tv_group_priority_groups(configs)
     tv_apk_download_path = url_for('download_tv_overlay_apk')
     tv_apk_download_url = (
         f"{BASE_URL}{tv_apk_download_path}"
@@ -1652,6 +1798,7 @@ def index():
         primary_chat_id=primary_chat_id,
         known_plates=known_plates,
         global_settings=global_settings,
+        tv_group_priority_groups=tv_group_priority_groups,
         tv_apk_download_url=tv_apk_download_url,
         current_version=CURRENT_VERSION,
     )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -235,6 +235,11 @@ def test_process_alert_dispatches_tv_alert_when_enabled(tmp_path, monkeypatch):
     monkeypatch.setattr(tasks, "send_telegram", lambda cfg, *_args, **_kwargs: cfg.update({"last_msg_id": 321}))
     monkeypatch.setattr(
         tv_delivery,
+        "should_dispatch_group_alert",
+        lambda *_args, **_kwargs: (True, config),
+    )
+    monkeypatch.setattr(
+        tv_delivery,
         "dispatch_tv_alert",
         lambda cfg, tag: dispatched.setdefault("call", {"config": cfg, "tag": tag}),
     )
@@ -295,6 +300,55 @@ def test_process_alert_logs_mjpg_skip_reason_without_rtsp_message(tmp_path, monk
 
     assert "TV dispatch skipped (no MJPG proxy URL)" in caplog.text
     assert "no RTSP URL" not in caplog.text
+
+
+def test_process_alert_skips_tv_dispatch_when_higher_priority_group_camera_is_active(tmp_path, monkeypatch, caplog):
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "id": "cfg-low",
+        "name": "Lower Driveway",
+        "request_id": "req12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+        "prompt": "Describe motion.",
+        "instant_notify": 0,
+        "send_video": 0,
+        "trigger_filename": "",
+        "tv_push_enabled": 1,
+        "tv_rtsp_url": "rtsp://camera/live",
+        "tv_duration_seconds": 25,
+        "tv_group": "driveway",
+    }
+
+    dispatch_calls = []
+
+    monkeypatch.setattr(tasks, "is_muted", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(tasks, "check_auto_mute", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(tasks, "build_prompt", lambda *_args, **_kwargs: "Describe motion.")
+    monkeypatch.setattr(tasks, "optimize_image", lambda *_args, **_kwargs: "encoded")
+    monkeypatch.setattr(tasks, "analyze_image_parallel", lambda *_args, **_kwargs: "Vehicle arrived")
+    monkeypatch.setattr(tasks, "send_telegram", lambda cfg, *_args, **_kwargs: cfg.update({"last_msg_id": 321}))
+    monkeypatch.setattr(
+        tv_delivery,
+        "should_dispatch_group_alert",
+        lambda *_args, **_kwargs: (
+            False,
+            {"id": "cfg-high", "name": "High Driveway"},
+        ),
+    )
+    monkeypatch.setattr(
+        tv_delivery,
+        "dispatch_tv_alert",
+        lambda *_args, **_kwargs: dispatch_calls.append(True),
+    )
+
+    with caplog.at_level(logging.INFO):
+        tasks.process_alert(str(image_path), config)
+
+    assert dispatch_calls == []
+    assert "TV dispatch skipped (higher-priority camera active: 'High Driveway')" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tv_delivery.py
+++ b/tests/test_tv_delivery.py
@@ -82,6 +82,102 @@ def test_higher_priority_camera_wins_group(tmp_path):
         wsgi.DB_FILE = original_db_file
 
 
+def test_should_dispatch_group_alert_blocks_lower_priority_when_higher_priority_is_active(tmp_path):
+    db_path = tmp_path / "group_priority_active.sqlite"
+    original_db_file = wsgi.DB_FILE
+
+    try:
+        wsgi.DB_FILE = str(db_path)
+        wsgi.init_db()
+        tv_delivery.set_group_priority("driveway", ["high", "low"])
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO configs (
+                    id, name, gemini_key, telegram_token, chat_id, prompt,
+                    tv_push_enabled, tv_rtsp_url, tv_duration_seconds, tv_group, last_triggered
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("high", "High Driveway", "g", "t", "c", "p", 1, "rtsp://high", 20, "driveway", "2026-04-18 10:00:05"),
+            )
+            conn.execute(
+                """
+                INSERT INTO configs (
+                    id, name, gemini_key, telegram_token, chat_id, prompt,
+                    tv_push_enabled, tv_rtsp_url, tv_duration_seconds, tv_group, last_triggered
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("low", "Lower Driveway", "g", "t", "c", "p", 1, "rtsp://low", 20, "driveway", "2026-04-18 10:00:00"),
+            )
+
+        should_dispatch, winner = tv_delivery.should_dispatch_group_alert(
+            {
+                "id": "low",
+                "name": "Lower Driveway",
+                "tv_push_enabled": 1,
+                "tv_rtsp_url": "rtsp://low",
+                "tv_duration_seconds": 20,
+                "tv_group": "driveway",
+                "last_triggered": "2026-04-18 10:00:00",
+            },
+            now_timestamp=1713434410.0,
+        )
+
+        assert should_dispatch is False
+        assert winner["id"] == "high"
+    finally:
+        wsgi.DB_FILE = original_db_file
+
+
+def test_should_dispatch_group_alert_allows_current_camera_when_higher_priority_is_inactive(tmp_path):
+    db_path = tmp_path / "group_priority_inactive.sqlite"
+    original_db_file = wsgi.DB_FILE
+
+    try:
+        wsgi.DB_FILE = str(db_path)
+        wsgi.init_db()
+        tv_delivery.set_group_priority("driveway", ["high", "low"])
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO configs (
+                    id, name, gemini_key, telegram_token, chat_id, prompt,
+                    tv_push_enabled, tv_rtsp_url, tv_duration_seconds, tv_group, last_triggered
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("high", "High Driveway", "g", "t", "c", "p", 1, "rtsp://high", 5, "driveway", "2026-04-18 10:00:00"),
+            )
+            conn.execute(
+                """
+                INSERT INTO configs (
+                    id, name, gemini_key, telegram_token, chat_id, prompt,
+                    tv_push_enabled, tv_rtsp_url, tv_duration_seconds, tv_group, last_triggered
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("low", "Lower Driveway", "g", "t", "c", "p", 1, "rtsp://low", 20, "driveway", "2026-04-18 10:00:10"),
+            )
+
+        should_dispatch, winner = tv_delivery.should_dispatch_group_alert(
+            {
+                "id": "low",
+                "name": "Lower Driveway",
+                "tv_push_enabled": 1,
+                "tv_rtsp_url": "rtsp://low",
+                "tv_duration_seconds": 20,
+                "tv_group": "driveway",
+                "last_triggered": "2026-04-18 10:00:10",
+            },
+            now_timestamp=1776506420.0,
+        )
+
+        assert should_dispatch is True
+        assert winner["id"] == "low"
+    finally:
+        wsgi.DB_FILE = original_db_file
+
+
 def test_group_winner_skips_camera_without_rtsp(tmp_path):
     db_path = tmp_path / "group_priority_rtsp.sqlite"
     original_db_file = wsgi.DB_FILE

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -639,6 +639,93 @@ def test_delete_paired_tv_redirects_back_to_tv_settings(client, tmp_path, monkey
         wsgi.DB_FILE = original_db_file
 
 
+def test_tv_group_priorities_render_saved_camera_order(client, tmp_path):
+    db_path = tmp_path / "tv_group_priority_index.sqlite"
+    original_db_file = wsgi.DB_FILE
+
+    try:
+        wsgi.DB_FILE = str(db_path)
+        wsgi.init_db()
+        wsgi.get_mute_status = lambda *_args, **_kwargs: []
+        wsgi.get_caption_mode = lambda *_args, **_kwargs: None
+
+        with sqlite3.connect(db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO configs (
+                    id, name, gemini_key, telegram_token, chat_id, prompt,
+                    tv_push_enabled, tv_rtsp_url, tv_duration_seconds, tv_group
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("cam-high", "High Driveway", "g", "t", "1", "p", 1, "rtsp://high", 20, "driveway"),
+            )
+            conn.execute(
+                """
+                INSERT INTO configs (
+                    id, name, gemini_key, telegram_token, chat_id, prompt,
+                    tv_push_enabled, tv_rtsp_url, tv_duration_seconds, tv_group
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                ("cam-low", "Lower Driveway", "g", "t", "1", "p", 1, "rtsp://low", 20, "driveway"),
+            )
+            conn.execute(
+                """
+                INSERT INTO camera_group_priorities (id, camera_id, group_name, priority)
+                VALUES (?, ?, ?, ?)
+                """,
+                (str(uuid.uuid4()), "cam-high", "driveway", 0),
+            )
+            conn.execute(
+                """
+                INSERT INTO camera_group_priorities (id, camera_id, group_name, priority)
+                VALUES (?, ?, ?, ?)
+                """,
+                (str(uuid.uuid4()), "cam-low", "driveway", 1),
+            )
+
+        response = client.get("/")
+
+        assert response.status_code == 200
+        html = response.data.decode("utf-8")
+        assert 'data-group-name="driveway"' in html
+        tv_priority_section = html.split('data-group-name="driveway"', 1)[1]
+        assert tv_priority_section.index("High Driveway") < tv_priority_section.index("Lower Driveway")
+    finally:
+        wsgi.DB_FILE = original_db_file
+
+
+def test_save_tv_group_priority_persists_order(client, tmp_path):
+    db_path = tmp_path / "tv_group_priority_save.sqlite"
+    original_db_file = wsgi.DB_FILE
+
+    try:
+        wsgi.DB_FILE = str(db_path)
+        wsgi.init_db()
+
+        response = client.post(
+            "/tv/groups/driveway/priority",
+            json={"camera_ids": ["cam-high", "cam-low"]},
+        )
+
+        assert response.status_code == 200
+
+        with sqlite3.connect(db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                """
+                SELECT camera_id, group_name, priority
+                FROM camera_group_priorities
+                ORDER BY priority ASC, created_at ASC, id ASC
+                """
+            ).fetchall()
+
+        assert [row["camera_id"] for row in rows] == ["cam-high", "cam-low"]
+        assert [row["priority"] for row in rows] == [0, 1]
+        assert all(row["group_name"] == "driveway" for row in rows)
+    finally:
+        wsgi.DB_FILE = original_db_file
+
+
 def test_get_log_entries_marks_webhook_trigger_and_alert_tag(tmp_path, monkeypatch):
     log_dir = tmp_path / "logs"
     log_dir.mkdir()


### PR DESCRIPTION
## Summary
- add a real TV Group Priorities editor in TV Settings with drag-and-drop ordering
- persist per-group camera order through the existing priority API
- enforce same-group priority during TV dispatch so lower-priority cameras are skipped while a higher-priority camera in that group is still active

## Verification
- `pytest -q tests/test_web.py tests/test_tv_delivery.py tests/test_tasks.py`
