### PR TITLE
Rename Android TV release APK asset

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -61,12 +61,12 @@ jobs:
 
       - name: Rename APK
         if: github.event_name == 'release'
-        run: cp app/build/outputs/apk/release/app-release.apk pipup-${{ github.ref_name }}.apk
+        run: cp app/build/outputs/apk/release/app-release.apk blue-iris-ai-hub-tv-${{ github.ref_name }}.apk
 
       - name: Upload APK to release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: android-tv-overlay/pipup-${{ github.ref_name }}.apk
+          files: android-tv-overlay/blue-iris-ai-hub-tv-${{ github.ref_name }}.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- stop publishing the Android TV release asset as `pipup-<version>.apk`
- publish the signed release asset as `blue-iris-ai-hub-tv-<version>.apk` instead

## Why

The Android TV app was rebranded to `Blue Iris AI Hub TV`, but the GitHub release workflow still renamed the APK to `pipup-...`, which leaked the old branding in release downloads.
