### PR TITLE
Update APK workflow actions for Node 24

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -19,15 +19,15 @@ jobs:
         working-directory: android-tv-overlay
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload debug APK artifact
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: android-tv-overlay-debug-apk
           path: android-tv-overlay/app/build/outputs/apk/debug/app-debug.apk
@@ -65,7 +65,7 @@ jobs:
 
       - name: Upload APK to release
         if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: android-tv-overlay/blue-iris-ai-hub-tv-${{ github.ref_name }}.apk
         env:

--- a/tests/test_workflow_action_versions.py
+++ b/tests/test_workflow_action_versions.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_node24_ready_action_versions_are_pinned():
+    build_apk = (REPO_ROOT / ".github" / "workflows" / "build-apk.yml").read_text()
+    ci_cd = (REPO_ROOT / ".github" / "workflows" / "ci-cd.yml").read_text()
+
+    assert "actions/checkout@v6" in build_apk
+    assert "actions/setup-java@v5" in build_apk
+    assert "actions/cache@v5" in build_apk
+    assert "actions/upload-artifact@v6" in build_apk
+    assert "softprops/action-gh-release@v3" in build_apk
+
+    assert "actions/checkout@v6" in ci_cd


### PR DESCRIPTION
## Summary

- upgrade the APK build workflow actions to Node 24-ready major versions
- leave `actions/delete-package-versions@v5` unchanged in the cleanup workflow
- add a regression test that locks the expected action major versions

## Updated actions

- `actions/checkout@v6`
- `actions/setup-java@v5`
- `actions/cache@v5`
- `actions/upload-artifact@v6`
- `softprops/action-gh-release@v3`

## Verification

- `pytest -q tests/test_workflow_action_versions.py`
