### PR TITLE
Preserve BI alert lookup metadata for export retries

### DIFF
--- a/app/bi_export_shared.py
+++ b/app/bi_export_shared.py
@@ -205,6 +205,7 @@ def recommended_action_for(error_code):
         "missing_clip_path": "check_prequeue_lookup_and_bvr_clip_fallback",
         "offset_unparseable": "check_alert_filename_format_and_offset_parser",
         "openbvr_failed": "check_blue_iris_clip_integrity_and_source_bvr_path",
+        "openbvr_failed_after_refresh": "check_bi_alert_lookup_row_selection_and_export_source_field",
         "openbvr_lookup_refresh_failed": "check_bi_alert_lookup_freshness_and_source_clip_path_after_openbvr_failure",
         "persistent_404": "check_bi_clip_endpoint_visibility_after_export_completion",
         "queue_ack_timeout": "check_bi_export_queue_acknowledgement_and_export_submission",
@@ -341,7 +342,7 @@ def trigger_bi_recovery(restart_url, restart_token, tag):
 def bi_lookup_alert(bi_url, bi_user, bi_pass, trigger_filename, tag):
     """
     Look up an alert in BI's alert list using the shared session cache.
-    Returns (clip, offset, msec) or None if the alert is not present.
+    Returns structured metadata for the selected row or None if the alert is not present.
     """
     json_url = urljoin(bi_url.rstrip("/") + "/", "json")
     sess, sid = get_session(bi_url, bi_user, bi_pass, tag)
@@ -354,9 +355,30 @@ def bi_lookup_alert(bi_url, bi_user, bi_pass, trigger_filename, tag):
         timeout=10,
     )
     alert_list.raise_for_status()
-    for alert in alert_list.json().get("data", []):
-        if alert.get("file") == trigger_filename:
-            return alert.get("clip"), alert.get("offset", 0), alert.get("msec", 10000)
+    exact_matches = [alert for alert in alert_list.json().get("data", []) if alert.get("file") == trigger_filename]
+    if exact_matches:
+        alert = exact_matches[0]
+        export_source_path = alert.get("path") or alert.get("clip")
+        export_source_field = "path" if alert.get("path") else "clip"
+        lookup_match_type = "exact_file"
+        if len(exact_matches) > 1:
+            lookup_match_type = "exact_file_duplicate_first"
+            logging.warning(
+                f"{tag} BI alert lookup found duplicate exact file matches; using first row | "
+                f"phase=prequeue_lookup lookup_result=duplicate_exact_file "
+                f"trigger_filename={trigger_filename} duplicate_count={len(exact_matches)}"
+            )
+        return {
+            "camera": alert.get("camera"),
+            "file": alert.get("file"),
+            "path": alert.get("path"),
+            "clip": alert.get("clip"),
+            "offset": alert.get("offset", 0),
+            "msec": alert.get("msec", 10000),
+            "lookup_match_type": lookup_match_type,
+            "export_source_path": export_source_path,
+            "export_source_field": export_source_field,
+        }
     return None
 
 

--- a/app/bi_exporter.py
+++ b/app/bi_exporter.py
@@ -94,10 +94,17 @@ def _refresh_export_request_after_openbvr(req, payload, tag):
         )
         return False, "BI alert lookup refresh found no matching alert after OpenBVR error"
 
-    clip_path, offset, duration = result
+    clip_path = result.get("export_source_path")
+    offset = result.get("offset", 0)
+    duration = result.get("msec", 10000)
     req["clip_path"] = clip_path
     req["offset"] = offset
     req["duration"] = duration
+    req["_lookup_file"] = result.get("file")
+    req["_lookup_path"] = result.get("path")
+    req["_lookup_clip"] = result.get("clip")
+    req["_lookup_match_type"] = result.get("lookup_match_type")
+    req["_export_source_field"] = result.get("export_source_field")
 
     refreshed_path = clip_path if clip_path.startswith("@") else f"@{clip_path}"
     if not refreshed_path.endswith(".bvr"):
@@ -110,13 +117,17 @@ def _refresh_export_request_after_openbvr(req, payload, tag):
     logger.info(
         f"{tag} BI alert lookup refreshed after OpenBVR error | "
         f"bi_instance={bi_instance_label(req['bi_url'])} phase=prequeue_lookup "
-        f"lookup_result=refreshed_after_openbvr_failure clip_path={clip_path} "
-        f"offset={offset} duration={duration}"
+        f"lookup_result=refreshed_after_openbvr_failure trigger_filename={trigger_filename} "
+        f"matched_file={result.get('file')} matched_path={result.get('path')} "
+        f"matched_clip={result.get('clip')} clip_path={clip_path} offset={offset} "
+        f"duration={duration} match_type={result.get('lookup_match_type')} "
+        f"export_source_field={result.get('export_source_field')}"
     )
     logger.info(
         f"{tag} Retrying BI export with refreshed alert metadata | "
         f"bi_instance={bi_instance_label(req['bi_url'])} phase=export_submit_retry "
-        f"retry_reason=openbvr_failed clip_path={clip_path} offset={offset} duration={duration}"
+        f"retry_reason=openbvr_failed clip_path={clip_path} offset={offset} duration={duration} "
+        f"export_source_field={result.get('export_source_field')}"
     )
     return True, None
 
@@ -264,6 +275,7 @@ def _prepare_export(req, tag):
                             )
                     if target_path and relative_uri:
                         break
+                return None, f"BI export failed after refreshed OpenBVR retry: {res.get('result')}"
 
         return None, f"BI export command failed: {res.get('result')}"
 
@@ -345,6 +357,8 @@ def _process_request(raw):
             error_code = "missing_export_target"
         elif error_msg and error_msg.startswith("BI alert lookup refresh"):
             error_code = "openbvr_lookup_refresh_failed"
+        elif error_msg and error_msg.startswith("BI export failed after refreshed OpenBVR retry"):
+            error_code = "openbvr_failed_after_refresh"
         elif error_msg == "openbvr deferred retry queued":
             return
         log_terminal_diagnosis(

--- a/app/tasks.py
+++ b/app/tasks.py
@@ -945,7 +945,9 @@ def build_bi_export_payload(config, output_path, tag, delivery_context=None):
                 trigger_filename, tag,
             )
             if result is not None:
-                clip_path, offset, duration = result
+                clip_path = result.get("export_source_path")
+                offset = result.get("offset", 0)
+                duration = result.get("msec", 10000)
                 log_alert_event(
                     logging.INFO,
                     tag,
@@ -953,9 +955,15 @@ def build_bi_export_payload(config, output_path, tag, delivery_context=None):
                     "prequeue_lookup",
                     bi_instance=config["bi_url"],
                     lookup_result="resolved",
+                    trigger_filename=trigger_filename,
+                    matched_file=result.get("file"),
+                    matched_path=result.get("path"),
+                    matched_clip=result.get("clip"),
                     clip_path=clip_path,
                     offset=offset,
                     duration=duration,
+                    match_type=result.get("lookup_match_type"),
+                    export_source_field=result.get("export_source_field"),
                 )
             elif bvr_clip:
                 clip_path = bvr_clip

--- a/tests/test_bi_export_pipeline.py
+++ b/tests/test_bi_export_pipeline.py
@@ -540,6 +540,60 @@ class TestSharedSessionCache:
         assert sid2 == "shared-sid"
 
 
+def test_bi_lookup_alert_returns_structured_metadata(monkeypatch):
+    alert_rows = [
+        {
+            "camera": "Garden",
+            "path": "@wrong_path.bvr",
+            "clip": "@wrong_clip.bvr",
+            "file": "Garden.20260418_170030.99999.3-1.jpg",
+            "offset": 99999,
+            "msec": 32115,
+        },
+        {
+            "camera": "Garden",
+            "path": "@4192553408.bvr",
+            "clip": "@4192491959.bvr",
+            "file": "Garden.20260418_170000.11995.3-1.jpg",
+            "offset": 11995,
+            "msec": 42557,
+        },
+    ]
+
+    class FakeSession:
+        def post(self, url, json=None, timeout=None):
+            class R:
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return {"data": alert_rows}
+
+            return R()
+
+    monkeypatch.setattr(bi_export_shared, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+
+    result = bi_export_shared.bi_lookup_alert(
+        "http://192.168.0.11:81",
+        "admin",
+        "secret",
+        "Garden.20260418_170000.11995.3-1.jpg",
+        "[Garden][d81bbc11]",
+    )
+
+    assert result == {
+        "camera": "Garden",
+        "file": "Garden.20260418_170000.11995.3-1.jpg",
+        "path": "@4192553408.bvr",
+        "clip": "@4192491959.bvr",
+        "offset": 11995,
+        "msec": 42557,
+        "lookup_match_type": "exact_file",
+        "export_source_path": "@4192553408.bvr",
+        "export_source_field": "path",
+    }
+
+
 class TestWatchdog:
     def setup_method(self):
         _clear_pipeline_state()
@@ -966,7 +1020,17 @@ def test_deferred_openbvr_retry_refreshes_alert_lookup_before_retry(monkeypatch)
     monkeypatch.setattr(
         bi_exporter,
         "bi_lookup_alert",
-        lambda *args, **kwargs: ("@clip/refreshed", 222, 33333),
+        lambda *args, **kwargs: {
+            "camera": "TestCam",
+            "file": "alert.jpg",
+            "path": "@clip/refreshed",
+            "clip": "@clip/ignored",
+            "offset": 222,
+            "msec": 33333,
+            "lookup_match_type": "exact_file",
+            "export_source_path": "@clip/refreshed",
+            "export_source_field": "path",
+        },
     )
 
     posted = []
@@ -1075,7 +1139,17 @@ def test_openbvr_idle_second_failure_refreshes_and_retries(monkeypatch):
     monkeypatch.setattr(
         bi_exporter,
         "bi_lookup_alert",
-        lambda *args, **kwargs: ("@clip/refreshed", 222, 33333),
+        lambda *args, **kwargs: {
+            "camera": "TestCam",
+            "file": "alert.jpg",
+            "path": "@clip/refreshed",
+            "clip": "@clip/ignored",
+            "offset": 222,
+            "msec": 33333,
+            "lookup_match_type": "exact_file",
+            "export_source_path": "@clip/refreshed",
+            "export_source_field": "path",
+        },
     )
 
     class FakeRedis:
@@ -1120,6 +1194,81 @@ def test_openbvr_idle_second_failure_refreshes_and_retries(monkeypatch):
     assert posted[2]["msec"] == 33333
 
 
+def test_openbvr_refresh_then_export_failure_uses_specific_terminal_error(monkeypatch):
+    payload = _request_payload(
+        clip_path="@clip/original",
+        offset=10,
+        duration=10000,
+        trigger_filename="Garden.20260418_170000.11995.3-1.jpg",
+    )
+
+    monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
+    monkeypatch.setattr(
+        bi_exporter,
+        "bi_lookup_alert",
+        lambda *args, **kwargs: {
+            "camera": "Garden",
+            "file": "Garden.20260418_170000.11995.3-1.jpg",
+            "path": "@4192553408.bvr",
+            "clip": "@4192491959.bvr",
+            "offset": 11995,
+            "msec": 42557,
+            "lookup_match_type": "exact_file",
+            "export_source_path": "@4192553408.bvr",
+            "export_source_field": "path",
+        },
+    )
+
+    class FakeRedis:
+        def scard(self, key):
+            assert key == bi_export_shared.ACTIVE_EXPORT_SET
+            return 0
+
+        def llen(self, key):
+            raise AssertionError("deferred queue depth should not be checked when idle")
+
+        def rpush(self, key, value):
+            raise AssertionError("should not defer when already idle")
+
+        def sadd(self, *args, **kwargs):
+            raise AssertionError("job should not be marked active on terminal export failure")
+
+    class FakeSession:
+        def __init__(self):
+            self.calls = 0
+
+        def post(self, url, json=None, timeout=None):
+            self.calls += 1
+
+            class R:
+                def __init__(self, body):
+                    self._body = body
+
+                def json(self):
+                    return self._body
+
+            if self.calls < 3:
+                return R({"result": "fail", "data": {"reason": "OpenBVR failed"}})
+            return R({"result": "fail", "data": {"reason": "fail"}})
+
+    terminal = {}
+    monkeypatch.setattr(bi_exporter, "r", FakeRedis())
+    monkeypatch.setattr(bi_exporter, "get_session", lambda *args, **kwargs: (FakeSession(), "sid"))
+    monkeypatch.setattr(
+        bi_exporter,
+        "log_terminal_diagnosis",
+        lambda _logger, _tag, _job, _phase, error_code, **extra: terminal.update(
+            {"error_code": error_code, **extra}
+        ),
+    )
+    monkeypatch.setattr(bi_exporter, "write_result", lambda *args, **kwargs: None)
+
+    bi_exporter._process_request(json.dumps(payload).encode())
+
+    assert terminal["error_code"] == "openbvr_failed_after_refresh"
+    assert terminal["error"] == "BI export failed after refreshed OpenBVR retry: fail"
+
+
 def test_defers_openbvr_retry_when_active_exports_running(monkeypatch):
     payload = _request_payload(
         clip_path="@clip/original",
@@ -1131,7 +1280,17 @@ def test_defers_openbvr_retry_when_active_exports_running(monkeypatch):
     monkeypatch.setattr(
         bi_exporter,
         "bi_lookup_alert",
-        lambda *args, **kwargs: ("@clip/refreshed", 222, 33333),
+        lambda *args, **kwargs: {
+            "camera": "TestCam",
+            "file": "alert.jpg",
+            "path": "@clip/refreshed",
+            "clip": "@clip/ignored",
+            "offset": 222,
+            "msec": 33333,
+            "lookup_match_type": "exact_file",
+            "export_source_path": "@clip/refreshed",
+            "export_source_field": "path",
+        },
     )
     monkeypatch.setattr(bi_exporter, "bi_get_export_queue", lambda *args, **kwargs: [])
 


### PR DESCRIPTION
## Summary
- return structured BI alert metadata from `bi_lookup_alert()` instead of the old tuple contract
- carry explicit export source selection and matched BI row details through prequeue lookup and OpenBVR refresh retries
- preserve a specific terminal error classification for refreshed OpenBVR retries that still fail

## Testing
- `pytest -q tests/test_bi_export_pipeline.py tests/test_tasks.py`

## Related
- Fixes #156