### PR TITLE
fix: dedup webhooks by bvr clip only

### DIFF
--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1187,7 +1187,7 @@ def webhook(config_id):
     bvr = request.form.get('bvr', '').strip()
     if bvr:
         dedup_key = f"clip_dedup:{bvr}"
-        if not r.set(dedup_key, 1, nx=True, ex=30):
+        if not r.set(dedup_key, 1, nx=True, ex=600):
             app.logger.info(f"{tag} Duplicate webhook for clip {bvr} — skipping.")
             return jsonify({"status": "duplicate", "camera": config['name']}), 200
         config['bvr_clip'] = bvr

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1158,6 +1158,16 @@ def delete_plate_audit():
 
 # --- Webhook ---
 
+def _dedup_time_bucket(filename, bucket_sec=10):
+    """Bucket a BI alert filename timestamp to suppress burst frames from a single motion event."""
+    m = re.search(r'(\d{8}_\d{6})', filename)
+    if not m:
+        return filename
+    ts = datetime.strptime(m.group(1), '%Y%m%d_%H%M%S')
+    bucketed = ts.replace(second=(ts.second // bucket_sec) * bucket_sec)
+    return bucketed.strftime('%Y%m%d_%H%M%S')
+
+
 @app.route('/webhook/<config_id>', methods=['POST'])
 def webhook(config_id):
     if 'image' not in request.files:
@@ -1186,8 +1196,9 @@ def webhook(config_id):
 
     bvr = request.form.get('bvr', '').strip()
     if bvr:
-        dedup_key = f"clip_dedup:{bvr}"
-        if not r.set(dedup_key, 1, nx=True, ex=600):
+        ts_bucket = _dedup_time_bucket(config['trigger_filename'])
+        dedup_key = f"clip_dedup:{bvr}:{ts_bucket}"
+        if not r.set(dedup_key, 1, nx=True, ex=30):
             app.logger.info(f"{tag} Duplicate webhook for clip {bvr} — skipping.")
             return jsonify({"status": "duplicate", "camera": config['name']}), 200
         config['bvr_clip'] = bvr

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1186,7 +1186,7 @@ def webhook(config_id):
 
     bvr = request.form.get('bvr', '').strip()
     if bvr:
-        dedup_key = f"clip_dedup:{bvr}:{config['trigger_filename']}"
+        dedup_key = f"clip_dedup:{bvr}"
         if not r.set(dedup_key, 1, nx=True, ex=30):
             app.logger.info(f"{tag} Duplicate webhook for clip {bvr} — skipping.")
             return jsonify({"status": "duplicate", "camera": config['name']}), 200

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -19,13 +19,13 @@ def _fake_image():
     return (io.BytesIO(b"\xff\xd8\xff\xe0" + b"\x00" * 16), "alert_20240101_120000.jpg")
 
 
-def test_webhook_dedup_same_bvr_returns_duplicate(client):
-    """Second request with the same bvr (any trigger filename) returns duplicate and does not enqueue."""
+def test_webhook_dedup_same_bvr_same_bucket_returns_duplicate(client):
+    """Burst frames within the same 10-second window on the same bvr are deduplicated."""
     config_id = uuid.uuid4().hex
     _insert_config(config_id)
 
     fake_redis = MagicMock()
-    fake_redis.set.side_effect = [1, None]  # first succeeds, second blocked
+    fake_redis.set.side_effect = [1, None]  # first sets key, second is blocked
     fake_queue = MagicMock()
 
     with patch.object(wsgi, "r", fake_redis), patch.object(wsgi, "q", fake_queue):
@@ -38,16 +38,49 @@ def test_webhook_dedup_same_bvr_returns_duplicate(client):
         assert r1.status_code == 200
         assert r1.get_json()["status"] == "queued"
 
+        # 3 seconds later — same 10-second bucket, so same dedup key
         img2, _ = _fake_image()
         r2 = client.post(
             f"/webhook/{config_id}",
-            data={"image": (img2, "alert_20240101_120040.jpg"), "bvr": "20240101_clip.bvr"},
+            data={"image": (img2, "alert_20240101_120003.jpg"), "bvr": "20240101_clip.bvr"},
             content_type="multipart/form-data",
         )
         assert r2.status_code == 200
         assert r2.get_json()["status"] == "duplicate"
 
     assert fake_queue.enqueue.call_count == 1
+
+
+def test_webhook_dedup_same_bvr_different_bucket_both_queue(client):
+    """Two distinct events on the same bvr clip (>10 s apart) both queue normally."""
+    config_id = uuid.uuid4().hex
+    _insert_config(config_id)
+
+    fake_redis = MagicMock()
+    fake_redis.set.return_value = 1  # always succeeds — different time-bucket keys
+    fake_queue = MagicMock()
+
+    with patch.object(wsgi, "r", fake_redis), patch.object(wsgi, "q", fake_queue):
+        img1, _ = _fake_image()
+        r1 = client.post(
+            f"/webhook/{config_id}",
+            data={"image": (img1, "alert_20240101_120000.jpg"), "bvr": "20240101_clip.bvr"},
+            content_type="multipart/form-data",
+        )
+        assert r1.status_code == 200
+        assert r1.get_json()["status"] == "queued"
+
+        # 45 seconds later — different 10-second bucket → distinct event, must not be suppressed
+        img2, _ = _fake_image()
+        r2 = client.post(
+            f"/webhook/{config_id}",
+            data={"image": (img2, "alert_20240101_120045.jpg"), "bvr": "20240101_clip.bvr"},
+            content_type="multipart/form-data",
+        )
+        assert r2.status_code == 200
+        assert r2.get_json()["status"] == "queued"
+
+    assert fake_queue.enqueue.call_count == 2
 
 
 def test_webhook_dedup_different_bvr_both_queue(client):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -19,8 +19,8 @@ def _fake_image():
     return (io.BytesIO(b"\xff\xd8\xff\xe0" + b"\x00" * 16), "alert_20240101_120000.jpg")
 
 
-def test_webhook_dedup_same_alert(client):
-    """Second request with same bvr+trigger_filename returns duplicate and does not enqueue."""
+def test_webhook_dedup_same_bvr_returns_duplicate(client):
+    """Second request with the same bvr (any trigger filename) returns duplicate and does not enqueue."""
     config_id = uuid.uuid4().hex
     _insert_config(config_id)
 
@@ -38,10 +38,10 @@ def test_webhook_dedup_same_alert(client):
         assert r1.status_code == 200
         assert r1.get_json()["status"] == "queued"
 
-        img2, name2 = _fake_image()
+        img2, _ = _fake_image()
         r2 = client.post(
             f"/webhook/{config_id}",
-            data={"image": (img2, name2), "bvr": "20240101_clip.bvr"},
+            data={"image": (img2, "alert_20240101_120040.jpg"), "bvr": "20240101_clip.bvr"},
             content_type="multipart/form-data",
         )
         assert r2.status_code == 200
@@ -50,8 +50,8 @@ def test_webhook_dedup_same_alert(client):
     assert fake_queue.enqueue.call_count == 1
 
 
-def test_webhook_dedup_different_trigger_on_same_bvr(client):
-    """Two alerts sharing the same .bvr but different trigger filenames both queue normally."""
+def test_webhook_dedup_different_bvr_both_queue(client):
+    """Two webhooks with different bvr clips both queue normally."""
     config_id = uuid.uuid4().hex
     _insert_config(config_id)
 
@@ -63,7 +63,7 @@ def test_webhook_dedup_different_trigger_on_same_bvr(client):
         img1, _ = _fake_image()
         r1 = client.post(
             f"/webhook/{config_id}",
-            data={"image": (img1, "alert_20240101_120000.jpg"), "bvr": "20240101_clip.bvr"},
+            data={"image": (img1, "alert_20240101_120000.jpg"), "bvr": "20240101_clip_a.bvr"},
             content_type="multipart/form-data",
         )
         assert r1.status_code == 200
@@ -72,7 +72,7 @@ def test_webhook_dedup_different_trigger_on_same_bvr(client):
         img2, _ = _fake_image()
         r2 = client.post(
             f"/webhook/{config_id}",
-            data={"image": (img2, "alert_20240101_120040.jpg"), "bvr": "20240101_clip.bvr"},
+            data={"image": (img2, "alert_20240101_120040.jpg"), "bvr": "20240101_clip_b.bvr"},
             content_type="multipart/form-data",
         )
         assert r2.status_code == 200


### PR DESCRIPTION
## Summary
- Changes dedup key from `clip_dedup:<bvr>:<trigger_filename>` to `clip_dedup:<bvr>`
- Blue Iris fires one webhook per motion frame, so the same `.bvr` clip arrives with multiple different trigger filenames — the old key only blocked exact same-frame duplicates, not the 4–5 frames per real event that the issue describes
- Updates tests: same bvr + different trigger filename now correctly returns `duplicate`; second test covers different bvr clips both queuing normally

## Test plan
- [ ] `pytest tests/test_web.py` — 9 passed
- [ ] Verify in production: single Gemini call per motion event instead of 4–5

Closes #69