### PR TITLE
fix: prevent Gemini from speculating vehicle make/model without a plate

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -132,6 +132,14 @@ CAPTION_PROMPTS = {
     ),
 }
 
+# Appended to every analysis prompt to prevent Gemini from speculating on
+# vehicle make/model when no plate is visible — the root cause of photo/video
+# caption conflicts described in issue #159.
+_NO_VEHICLE_SPECULATION = (
+    " Do not state a vehicle make or model unless you can clearly read"
+    " the number plate in the image or video."
+)
+
 
 # =============================================================================
 # Helpers
@@ -307,10 +315,10 @@ def build_prompt(config):
     plate_note = f" Known plates: {plate_hint}." if plate_hint else ""
 
     if mode != 'normal' and mode in CAPTION_PROMPTS:
-        return CAPTION_PROMPTS[mode] + plate_note
+        return CAPTION_PROMPTS[mode] + plate_note + _NO_VEHICLE_SPECULATION
 
     base = config.get('prompt', 'Describe any motion detected by this CCTV camera in one sentence.')
-    return base + plate_note
+    return base + plate_note + _NO_VEHICLE_SPECULATION
 
 
 def is_muted(config):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -284,6 +284,51 @@ def test_enrich_caption_without_plate_returns_original_text(monkeypatch):
     assert caption == "Vehicle arrived on driveway"
 
 
+class _FakeRedis:
+    """Minimal Redis stub for build_prompt tests."""
+    def __init__(self, caption_mode_value=None):
+        self._value = caption_mode_value
+
+    def get(self, _key):
+        return self._value
+
+
+def test_build_prompt_appends_no_vehicle_speculation_in_normal_mode(monkeypatch):
+    monkeypatch.setattr(tasks, "r", _FakeRedis())
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {})
+
+    prompt = tasks.build_prompt({"chat_id": "123", "prompt": "Describe motion."})
+
+    assert "Describe motion." in prompt
+    assert tasks._NO_VEHICLE_SPECULATION in prompt
+
+
+def test_build_prompt_appends_no_vehicle_speculation_in_caption_mode(monkeypatch):
+    import json
+    from datetime import datetime, timedelta
+
+    expires = (datetime.now() + timedelta(hours=1)).isoformat()
+    mode_data = json.dumps({"mode": "hilarious", "expires": expires}).encode()
+    monkeypatch.setattr(tasks, "r", _FakeRedis(caption_mode_value=mode_data))
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {})
+
+    prompt = tasks.build_prompt({"chat_id": "123"})
+
+    assert tasks.CAPTION_PROMPTS["hilarious"] in prompt
+    assert tasks._NO_VEHICLE_SPECULATION in prompt
+
+
+def test_build_prompt_includes_known_plates_before_speculation_note(monkeypatch):
+    monkeypatch.setattr(tasks, "r", _FakeRedis())
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {"AB12CDE": "Owner"})
+
+    prompt = tasks.build_prompt({"chat_id": "123", "prompt": "Describe motion."})
+
+    plate_pos = prompt.index("AB12CDE")
+    specul_pos = prompt.index(tasks._NO_VEHICLE_SPECULATION)
+    assert plate_pos < specul_pos
+
+
 def test_process_alert_dispatches_tv_alert_when_enabled(tmp_path, monkeypatch):
     image_path = tmp_path / "alert.jpg"
     image_path.write_bytes(b"fake-image")


### PR DESCRIPTION
## Summary

- Adds a `_NO_VEHICLE_SPECULATION` module-level constant to `tasks.py` containing the instruction Gemini must follow: do not state a vehicle make or model unless the number plate is clearly readable in the image or video
- Appends it in `build_prompt()` on both return paths — normal mode and all caption modes (hilarious/witty/rude) — so it is present in every prompt without modifying user-configurable camera prompts
- Adds three tests covering: normal mode, caption mode, and correct ordering relative to the known-plate hint

## Root cause

`build_prompt()` returned the user's prompt plus an optional plate hint with no constraint on speculation. Gemini would infer make/model from vehicle shape alone and state it with false confidence. Because no plate appeared in the output, DVLA enrichment never ran on the still caption. The subsequent video pass correctly read the plate and produced a conflicting, DVLA-enriched caption.

## What was not changed

- The DVLA enrichment pipeline is unchanged — if Gemini now reads a plate in the still, enrichment will fire there too
- No prompt splitting between photo and video paths; the same `_NO_VEHICLE_SPECULATION` constraint is appropriate for both

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)