### PR TITLE
fix: bounded retry and degraded-mode tracking for still-photo send

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -81,12 +81,16 @@ def log_telegram_event(
     caption_changed=None,
     message_id=None,
     reason=None,
+    error_category=None,
+    attempt=None,
 ):
     log = _resolve_logger(service_logger)
     suffix = _format_log_fields(
         phase=phase,
         error_code=error_code,
         reason=reason,
+        error_category=error_category,
+        attempt=attempt,
         **_telegram_log_fields(
             config,
             text=text,
@@ -175,6 +179,34 @@ def _safe_telegram_response_error(resp):
     if status:
         return f"status={status}"
     return type(resp).__name__
+
+
+def _classify_telegram_error(status_code=None, exc=None):
+    """Map a Telegram send failure to a retriability category."""
+    if exc is not None:
+        if isinstance(exc, (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RequestException,
+        )):
+            return "transport"
+        return "unknown"
+    if status_code is None:
+        return "unknown"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code in (401, 403):
+        return "auth"
+    if status_code in (400, 404):
+        return "bad_request"
+    if status_code >= 500:
+        return "server_error"
+    return "unknown"
+
+
+_RETRIABLE_CATEGORIES = frozenset({"transport", "rate_limited", "server_error"})
+# Delay in seconds before each attempt (index 0 = attempt 1, so first attempt is immediate).
+_STILL_RETRY_DELAYS = (0, 2, 5)
 
 
 def get_api_keys(config):
@@ -639,7 +671,7 @@ def _tg_thread(config):
     return str(t) if t else None
 
 
-def send_telegram(config, img_path, caption, service_logger=None):
+def send_telegram(config, img_path, caption, service_logger=None, max_attempts=3):
     req_id = config.get('request_id', 'unknown')
     tag = f"[{config['name']}][{req_id}]"
 
@@ -651,12 +683,19 @@ def send_telegram(config, img_path, caption, service_logger=None):
     data = {'chat_id': chat_id, 'caption': caption}
     if thread_id:
         data['message_thread_id'] = thread_id
-    try:
-        with open(img_path, 'rb') as f:
-            resp = requests.post(url, files={'photo': f}, data=data, timeout=15)
+
+    for attempt in range(1, max_attempts + 1):
+        delay = _STILL_RETRY_DELAYS[attempt - 1] if attempt - 1 < len(_STILL_RETRY_DELAYS) else _STILL_RETRY_DELAYS[-1]
+        if delay:
+            time.sleep(delay)
+        attempt_label = f"{attempt}/{max_attempts}"
+        try:
+            with open(img_path, 'rb') as f:
+                resp = requests.post(url, files={'photo': f}, data=data, timeout=15)
             if resp.ok:
                 message_id = resp.json()['result']['message_id']
                 config['last_msg_id'] = message_id
+                config.pop('still_delivery_failed', None)
                 log_telegram_event(
                     logging.INFO,
                     tag,
@@ -668,28 +707,42 @@ def send_telegram(config, img_path, caption, service_logger=None):
                     caption_source="still",
                     message_id=message_id,
                 )
-            else:
-                log_telegram_event(
-                    logging.ERROR,
-                    tag,
-                    "Telegram photo send failed",
-                    "telegram_photo_send_failed",
-                    config,
-                    service_logger=service_logger,
-                    error_code="telegram_photo_send_failed",
-                    reason=_safe_telegram_response_error(resp),
-                )
-    except Exception as exc:
-        log_telegram_event(
-            logging.ERROR,
-            tag,
-            "Telegram photo send error",
-            "telegram_photo_send_failed",
-            config,
-            service_logger=service_logger,
-            error_code="telegram_photo_send_failed",
-            reason=_safe_request_error(exc),
-        )
+                return
+            error_category = _classify_telegram_error(status_code=resp.status_code)
+            is_terminal = error_category not in _RETRIABLE_CATEGORIES or attempt == max_attempts
+            log_telegram_event(
+                logging.ERROR if is_terminal else logging.WARNING,
+                tag,
+                "Telegram photo send failed",
+                "telegram_photo_send_failed",
+                config,
+                service_logger=service_logger,
+                error_code="telegram_photo_send_failed",
+                reason=_safe_telegram_response_error(resp),
+                error_category=error_category,
+                attempt=attempt_label,
+            )
+            if is_terminal:
+                break
+        except Exception as exc:
+            error_category = _classify_telegram_error(exc=exc)
+            is_terminal = error_category not in _RETRIABLE_CATEGORIES or attempt == max_attempts
+            log_telegram_event(
+                logging.ERROR if is_terminal else logging.WARNING,
+                tag,
+                "Telegram photo send error",
+                "telegram_photo_send_failed",
+                config,
+                service_logger=service_logger,
+                error_code="telegram_photo_send_failed",
+                reason=_safe_request_error(exc),
+                error_category=error_category,
+                attempt=attempt_label,
+            )
+            if is_terminal:
+                break
+
+    config['still_delivery_failed'] = True
 
 
 def update_telegram_caption(config, text, service_logger=None, caption_source="unknown", previous_text=None):
@@ -1276,6 +1329,7 @@ def process_alert(image_path, config):
                     },
                     "prompt": prompt,
                     "still_caption": still_caption,
+                    "still_delivery_failed": config.get("still_delivery_failed", False),
                 }
                 payload = export_payload_future.result() if export_payload_future else build_bi_export_payload(
                     config,
@@ -1343,6 +1397,7 @@ def process_alert(image_path, config):
             final_status=final_status,
             recommended_action=recommended_action_for(summary_error_code),
             send_video=config.get('send_video') == 1,
+            still_delivery_failed=True if config.get('still_delivery_failed') else None,
             trigger_filename=bool(config.get('trigger_filename')),
         )
         for p in [image_path, raw_mp4, optimised_mp4]:

--- a/app/video_delivery_worker.py
+++ b/app/video_delivery_worker.py
@@ -101,6 +101,17 @@ def _process_delivery_request(request_id):
             logger.info(f"{job_tag(job)} delivery already completed; skipping duplicate queue item")
             return
 
+        if delivery.get("still_delivery_failed"):
+            log_telegram_event(
+                logging.WARNING,
+                job_tag(job),
+                "Alert running in degraded mode: still photo was not delivered; video will be sent as new message",
+                "alert_degraded_still_not_delivered",
+                config,
+                service_logger=logger,
+                error_code="still_delivery_failed",
+            )
+
         tag = job_tag(job)
         raw_mp4 = job["output_path"]
         optimised_mp4 = _optimised_path(raw_mp4)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -648,3 +648,169 @@ def test_replace_telegram_media_fallback_sets_last_msg_id_for_caption_update(tmp
 
     assert any("sendAnimation" in c for c in calls)
     assert any("editMessageCaption" in c for c in calls)
+
+
+# ---------------------------------------------------------------------------
+# send_telegram — retry and degraded-mode tests (issue #135)
+# ---------------------------------------------------------------------------
+
+class _CountingResponse:
+    """Fails for the first `fail_count` calls, then succeeds."""
+
+    def __init__(self, fail_count=1, fail_status=500, success_payload=None):
+        self._calls = 0
+        self._fail_count = fail_count
+        self._fail_status = fail_status
+        self._success_payload = success_payload or {"result": {"message_id": 42}}
+
+    def __call__(self, *args, **kwargs):
+        self._calls += 1
+        if self._calls <= self._fail_count:
+            return _DummyResponse(ok=False, status_code=self._fail_status)
+        return _DummyResponse(ok=True, payload=self._success_payload)
+
+    @property
+    def call_count(self):
+        return self._calls
+
+
+def test_send_telegram_retries_on_server_error_then_succeeds(tmp_path, monkeypatch, caplog):
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+    }
+
+    responder = _CountingResponse(fail_count=1, fail_status=503)
+    monkeypatch.setattr(tasks.requests, "post", responder)
+    monkeypatch.setattr(tasks.time, "sleep", lambda _: None)
+
+    with caplog.at_level(logging.INFO):
+        tasks.send_telegram(config, str(image_path), "Motion detected.", max_attempts=3)
+
+    assert config.get("last_msg_id") == 42
+    assert not config.get("still_delivery_failed")
+    assert responder.call_count == 2
+    assert "phase=telegram_photo_send_failed" in caplog.text
+    assert "error_category=server_error" in caplog.text
+    assert "phase=telegram_photo_sent" in caplog.text
+
+
+def test_send_telegram_no_retry_on_auth_error(tmp_path, monkeypatch, caplog):
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+    }
+
+    call_count = {"n": 0}
+
+    def fake_post(*args, **kwargs):
+        call_count["n"] += 1
+        return _DummyResponse(ok=False, status_code=401,
+                               payload={"description": "Unauthorized"})
+
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+    monkeypatch.setattr(tasks.time, "sleep", lambda _: None)
+
+    with caplog.at_level(logging.ERROR):
+        tasks.send_telegram(config, str(image_path), "Motion detected.", max_attempts=3)
+
+    assert call_count["n"] == 1
+    assert config.get("still_delivery_failed") is True
+    assert "error_category=auth" in caplog.text
+    assert "attempt=1/3" in caplog.text
+
+
+def test_send_telegram_all_retries_exhausted_sets_degraded_flag(tmp_path, monkeypatch, caplog):
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+    }
+
+    monkeypatch.setattr(
+        tasks.requests,
+        "post",
+        lambda *args, **kwargs: _DummyResponse(ok=False, status_code=503),
+    )
+    monkeypatch.setattr(tasks.time, "sleep", lambda _: None)
+
+    with caplog.at_level(logging.WARNING):
+        tasks.send_telegram(config, str(image_path), "Motion detected.", max_attempts=3)
+
+    assert config.get("still_delivery_failed") is True
+    assert not config.get("last_msg_id")
+    assert "attempt=3/3" in caplog.text
+    assert "error_category=server_error" in caplog.text
+
+
+def test_send_telegram_transport_error_is_retriable(tmp_path, monkeypatch, caplog):
+    import requests as req_lib
+
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+    }
+
+    call_count = {"n": 0}
+
+    def fake_post(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] < 3:
+            raise req_lib.exceptions.ConnectionError("network down")
+        return _DummyResponse(ok=True, payload={"result": {"message_id": 99}})
+
+    monkeypatch.setattr(tasks.requests, "post", fake_post)
+    monkeypatch.setattr(tasks.time, "sleep", lambda _: None)
+
+    with caplog.at_level(logging.WARNING):
+        tasks.send_telegram(config, str(image_path), "Motion detected.", max_attempts=3)
+
+    assert config.get("last_msg_id") == 99
+    assert not config.get("still_delivery_failed")
+    assert call_count["n"] == 3
+    assert "error_category=transport" in caplog.text
+
+
+def test_send_telegram_success_after_prior_failure_clears_degraded_flag(tmp_path, monkeypatch):
+    """A successful retry clears any still_delivery_failed flag left from a prior call."""
+    image_path = tmp_path / "alert.jpg"
+    image_path.write_bytes(b"fake-image")
+
+    config = {
+        "name": "Driveway",
+        "request_id": "abc12345",
+        "telegram_token": "token",
+        "chat_id": "chat",
+        "still_delivery_failed": True,
+    }
+
+    monkeypatch.setattr(
+        tasks.requests,
+        "post",
+        lambda *args, **kwargs: _DummyResponse(ok=True, payload={"result": {"message_id": 7}}),
+    )
+    monkeypatch.setattr(tasks.time, "sleep", lambda _: None)
+
+    tasks.send_telegram(config, str(image_path), "Motion detected.")
+
+    assert config.get("last_msg_id") == 7
+    assert not config.get("still_delivery_failed")


### PR DESCRIPTION
## Summary

- **Bounded retries**: `send_telegram()` now attempts up to 3 times (0 s → 2 s → 5 s back-off). Non-retriable errors (auth `401`/`403`, bad request `400`/`404`) short-circuit immediately; retriable errors (transport, `429`, `5xx`) exhaust all attempts.
- **Error categorisation**: every failure log line now includes `error_category=<transport|auth|bad_request|rate_limited|server_error>` and `attempt=N/M` so transport, auth, and permanent failures are distinguishable without regex heuristics.
- **Degraded-mode tracking**: when all attempts are exhausted, `config['still_delivery_failed']` is set. This flag is propagated into the BI export `delivery_context` and:
  - The video delivery worker logs `alert_degraded_still_not_delivered` so the degraded state is visible in video-pipeline logs.
  - The `alert_summary` event includes `still_delivery_failed=true` so still and video delivery outcomes are independently measurable.
- A successful retry (including the instant-notify fallback path) clears `still_delivery_failed` so a later successful send is not falsely flagged.

## Root cause

`send_telegram()` made exactly one HTTP attempt. On any failure it logged `telegram_photo_send_failed` and returned, leaving `config['last_msg_id']` unset. The video pipeline could partially compensate via `sendAnimation` fallback, but this was silent and not observable as degraded.

## Test plan

- [x] `test_send_telegram_retries_on_server_error_then_succeeds` — 503 on attempt 1, success on attempt 2; `last_msg_id` set, `still_delivery_failed` not set, two HTTP calls made
- [x] `test_send_telegram_no_retry_on_auth_error` — 401 → single call only, `still_delivery_failed=True`, `error_category=auth` in log
- [x] `test_send_telegram_all_retries_exhausted_sets_degraded_flag` — three 503s → `still_delivery_failed=True`, `attempt=3/3` in log
- [x] `test_send_telegram_transport_error_is_retriable` — `ConnectionError` on attempts 1-2, success on attempt 3
- [x] `test_send_telegram_success_after_prior_failure_clears_degraded_flag` — pre-seeded `still_delivery_failed=True` is cleared on success
- [x] All 62 non-Redis tests pass; no regressions

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)