### PR TITLE
fix: isolate redis-backed tests to db 15

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
           export DATA_DIR=./test_data
           export LOG_FILE=./test_logs/system.log
           export TEMP_IMAGE_DIR=./test_tmp
-          export REDIS_URL=redis://localhost:6379/0
+          export REDIS_URL=redis://localhost:6379/15
           pytest
 
   build-and-push:

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ __pycache__/
 *.pyd
 .venv/
 .pytest_cache/
+.worktrees/
 
 # Docker volumes
 /dev/shm/

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,19 @@
-import pytest
+import importlib
 import os
 import tempfile
-import redis
 
-os.environ["REDIS_URL"] = "redis://localhost:6379/15"
+import redis
+import pytest
+
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
 
 _test_redis = redis.from_url(os.environ["REDIS_URL"])
 
-import wsgi
-import settings_store
+
+def _test_app_modules():
+    wsgi = importlib.import_module("wsgi")
+    settings_store = importlib.import_module("settings_store")
+    return wsgi, settings_store
 
 
 @pytest.fixture(autouse=True)
@@ -20,16 +25,17 @@ def isolate_redis_db():
 @pytest.fixture
 def client():
     """Configures the app for testing with a temporary database."""
+    wsgi, settings_store = _test_app_modules()
     db_fd, db_path = tempfile.mkstemp()
-    
-    wsgi.app.config['TESTING'] = True
+
+    wsgi.app.config["TESTING"] = True
     wsgi.DB_FILE = db_path
     wsgi.LOG_FILE = os.path.join(os.path.dirname(db_path), "test.log")
     settings_store.DB_FILE = db_path
-    
+
     with wsgi.app.test_client() as client:
         with wsgi.app.app_context():
-            wsgi.init_db() 
+            wsgi.init_db()
         yield client
 
     os.close(db_fd)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 import os
 import tempfile
+
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
+
 import wsgi
 import settings_store
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import tempfile
 
-os.environ.setdefault("REDIS_URL", "redis://localhost:6379/15")
+os.environ["REDIS_URL"] = "redis://localhost:6379/15"
 
 import wsgi
 import settings_store

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,21 @@
 import pytest
 import os
 import tempfile
+import redis
 
 os.environ["REDIS_URL"] = "redis://localhost:6379/15"
 
+_test_redis = redis.from_url(os.environ["REDIS_URL"])
+
 import wsgi
 import settings_store
+
+
+@pytest.fixture(autouse=True)
+def isolate_redis_db():
+    _test_redis.flushdb()
+    yield
+    _test_redis.flushdb()
 
 @pytest.fixture
 def client():

--- a/tests/test_redis_test_isolation.py
+++ b/tests/test_redis_test_isolation.py
@@ -1,0 +1,15 @@
+import os
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_test_suite_defaults_redis_url_to_isolated_db_15():
+    assert os.environ["REDIS_URL"] == "redis://localhost:6379/15"
+
+
+def test_ci_uses_isolated_redis_db_for_tests():
+    ci_cd = (REPO_ROOT / ".github" / "workflows" / "ci-cd.yml").read_text()
+
+    assert "export REDIS_URL=redis://localhost:6379/15" in ci_cd

--- a/tests/test_redis_test_isolation.py
+++ b/tests/test_redis_test_isolation.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import redis
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -13,3 +14,15 @@ def test_ci_uses_isolated_redis_db_for_tests():
     ci_cd = (REPO_ROOT / ".github" / "workflows" / "ci-cd.yml").read_text()
 
     assert "export REDIS_URL=redis://localhost:6379/15" in ci_cd
+
+
+def test_conftest_flushes_the_isolated_redis_db_between_tests():
+    conftest = (REPO_ROOT / "tests" / "conftest.py").read_text()
+
+    assert "flushdb()" in conftest
+
+
+def test_configured_test_redis_db_starts_empty():
+    client = redis.from_url(os.environ["REDIS_URL"])
+
+    assert client.dbsize() == 0


### PR DESCRIPTION
## Summary
- default the test harness `REDIS_URL` to `redis://localhost:6379/15` before app modules import Redis clients
- update the CI test job to use Redis DB 15 as well, so local and CI Redis-backed runs use the same isolated database
- add a regression test that locks both the test-harness default and the CI workflow setting

## Testing
- `pytest -q tests/test_redis_test_isolation.py`
- `pytest -q tests/test_bi_export_pipeline.py`

## Related
- Fixes #160