### PR TITLE
Fix Gemini vehicle identity guesses before DVLA enrichment

### DIFF
--- a/app/tasks.py
+++ b/app/tasks.py
@@ -132,6 +132,12 @@ CAPTION_PROMPTS = {
     ),
 }
 
+DVLA_PROMPT_GUARD = (
+    " If a vehicle registration is visible, include the registration but do not guess "
+    "vehicle make or model; say car, van, or vehicle instead. DVLA will add official "
+    "make, colour, and year."
+)
+
 
 # =============================================================================
 # Helpers
@@ -306,11 +312,13 @@ def build_prompt(config):
     plate_hint = "; ".join(f"{p} = {n}" for p, n in plates.items()) if plates else ""
     plate_note = f" Known plates: {plate_hint}." if plate_hint else ""
 
+    dvla_note = DVLA_PROMPT_GUARD if (config.get('dvla_api_key') or '').strip() else ""
+
     if mode != 'normal' and mode in CAPTION_PROMPTS:
-        return CAPTION_PROMPTS[mode] + plate_note
+        return CAPTION_PROMPTS[mode] + plate_note + dvla_note
 
     base = config.get('prompt', 'Describe any motion detected by this CCTV camera in one sentence.')
-    return base + plate_note
+    return base + plate_note + dvla_note
 
 
 def is_muted(config):

--- a/app/wsgi.py
+++ b/app/wsgi.py
@@ -1316,7 +1316,7 @@ HTML_TEMPLATE = r"""
                                 <div class="col-md-6 mb-3"><label class="form-label">Telegram Chat ID</label><input type="text" name="chat_id" class="form-control" required></div>
                                 <div class="col-md-6 mb-3"><label class="form-label">Message Thread ID <span class="text-muted small">(optional)</span></label><input type="text" name="message_thread_id" class="form-control" placeholder="Topic/thread ID"></div>
                             </div>
-                            <div class="mb-3"><label class="form-label">AI Prompt</label><textarea name="prompt" class="form-control" rows="3" required>The CCTV has detected motion. Describe any motion in a single sentence (max 145 characters) — vehicles (colour, make, plate), people, or deliveries. Do not describe static objects.</textarea></div>
+                            <div class="mb-3"><label class="form-label">AI Prompt</label><textarea name="prompt" class="form-control" rows="3" required>The CCTV has detected motion. Describe any motion in a single sentence (max 145 characters): vehicles (colour and plate if readable), people, or deliveries. Do not guess vehicle make or model. Do not describe static objects.</textarea></div>
                             <hr>
                             <h6 class="text-primary">Video Export</h6>
                             <div class="row">

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -100,6 +100,45 @@ def test_update_telegram_caption_logs_source_and_change(monkeypatch, caplog):
     assert "message_id=654" in caplog.text
 
 
+def test_build_prompt_adds_dvla_vehicle_identity_guard(monkeypatch):
+    monkeypatch.setattr(tasks.r, "get", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {})
+
+    prompt = tasks.build_prompt(
+        {
+            "chat_id": "chat",
+            "prompt": "Describe motion.",
+            "dvla_api_key": "test-key",
+        }
+    )
+
+    assert "Describe motion." in prompt
+    assert "do not guess vehicle make or model" in prompt
+    assert "DVLA will add official make, colour, and year" in prompt
+
+
+def test_build_prompt_adds_dvla_guard_to_caption_modes(monkeypatch):
+    monkeypatch.setattr(
+        tasks.r,
+        "get",
+        lambda *_args, **_kwargs: (
+            b'{"mode": "witty", "expires": "2999-01-01T00:00:00"}'
+        ),
+    )
+    monkeypatch.setattr(tasks, "load_known_plates", lambda: {})
+
+    prompt = tasks.build_prompt(
+        {
+            "chat_id": "chat",
+            "prompt": "Describe motion.",
+            "dvla_api_key": "test-key",
+        }
+    )
+
+    assert "witty" in prompt
+    assert "do not guess vehicle make or model" in prompt
+
+
 def test_process_alert_does_not_log_dvla_enrichment_without_key(tmp_path, monkeypatch, caplog):
     image_path = tmp_path / "alert.jpg"
     image_path.write_bytes(b"fake-image")


### PR DESCRIPTION
## Summary
- add a DVLA-aware prompt guard so Gemini includes visible registrations but does not guess vehicle make/model
- apply the guard to normal prompts and temporary caption modes
- update the default new-camera prompt to avoid asking for make/model

## Tests
- LOG_FILE=/tmp/blueiris-test.log DATA_DIR=/tmp/blueiris-test-data TEMP_IMAGE_DIR=/tmp/blueiris-test-images PYTHONPATH=app uv run pytest tests/test_tasks.py -q
- LOG_FILE=/tmp/blueiris-test.log DATA_DIR=/tmp/blueiris-test-data TEMP_IMAGE_DIR=/tmp/blueiris-test-images PYTHONPATH=app uv run pytest tests/test_web.py -q